### PR TITLE
Enable naming / sharing for all RT queryable model objects

### DIFF
--- a/src/clients/KDTree/KDTree.cpp
+++ b/src/clients/KDTree/KDTree.cpp
@@ -4,6 +4,6 @@ int main(int argc, char *argv[]) {
   using namespace fluid::client;
   if (!argc) std::cerr << "Please pass a folder to write to";
   std::cout << "Write JSON to " << argv[1];
-  ParameterDump<RTKDTreeClient>::dump("KDTree", argv[1]);
+  ParameterDump<NRTThreadedKDTreeClient>::dump("KDTree", argv[1]);
   return 0;
 }

--- a/src/clients/KMeans/KMeans.cpp
+++ b/src/clients/KMeans/KMeans.cpp
@@ -4,6 +4,6 @@ int main(int argc, char *argv[]) {
   using namespace fluid::client;
   if (!argc) std::cerr << "Please pass a folder to write to";
   std::cout << "Write JSON to " << argv[1];
-  ParameterDump<RTKMeansClient>::dump("KMeans", argv[1]);
+  ParameterDump<NRTThreadedKMeansClient>::dump("KMeans", argv[1]);
   return 0;
 }

--- a/src/clients/KNNClassifier/KNNClassifier.cpp
+++ b/src/clients/KNNClassifier/KNNClassifier.cpp
@@ -4,6 +4,6 @@ int main(int argc, char *argv[]) {
   using namespace fluid::client;
   if (!argc) std::cerr << "Please pass a folder to write to";
   std::cout << "Write JSON to " << argv[1];
-  ParameterDump<RTKNNClassifierClient>::dump("KNNClassifier", argv[1]);
+  ParameterDump<NRTThreadedKNNClassifierClient>::dump("KNNClassifier", argv[1]);
   return 0;
 }

--- a/src/clients/KNNRegressor/KNNRegressor.cpp
+++ b/src/clients/KNNRegressor/KNNRegressor.cpp
@@ -4,6 +4,6 @@ int main(int argc, char *argv[]) {
   using namespace fluid::client;
   if (!argc) std::cerr << "Please pass a folder to write to";
   std::cout << "Write JSON to " << argv[1];
-  ParameterDump<RTKNNRegressorClient>::dump("KNNRegressor", argv[1]);
+  ParameterDump<NRTThreadedKNNRegressorClient>::dump("KNNRegressor", argv[1]);
   return 0;
 }

--- a/src/clients/MLPClassifier/MLPClassifier.cpp
+++ b/src/clients/MLPClassifier/MLPClassifier.cpp
@@ -4,6 +4,6 @@ int main(int argc, char *argv[]) {
   using namespace fluid::client;
   if (!argc) std::cerr << "Please pass a folder to write to";
   std::cout << "Write JSON to " << argv[1];
-  ParameterDump<RTMLPClassifierClient>::dump("MLPClassifier", argv[1]);
+  ParameterDump<NRTThreadedMLPClassifierClient>::dump("MLPClassifier", argv[1]);
   return 0;
 }

--- a/src/clients/MLPRegressor/MLPRegressor.cpp
+++ b/src/clients/MLPRegressor/MLPRegressor.cpp
@@ -4,6 +4,6 @@ int main(int argc, char *argv[]) {
   using namespace fluid::client;
   if (!argc) std::cerr << "Please pass a folder to write to";
   std::cout << "Write JSON to " << argv[1];
-  ParameterDump<RTMLPRegressorClient>::dump("MLPRegressor", argv[1]);
+  ParameterDump<NRTThreadedMLPRegressorClient>::dump("MLPRegressor", argv[1]);
   return 0;
 }

--- a/src/clients/Normalize/Normalize.cpp
+++ b/src/clients/Normalize/Normalize.cpp
@@ -4,6 +4,6 @@ int main(int argc, char *argv[]) {
   using namespace fluid::client;
   if (!argc) std::cerr << "Please pass a folder to write to";
   std::cout << "Write JSON to " << argv[1];
-  ParameterDump<RTNormalizeClient>::dump("Normalize", argv[1]);
+  ParameterDump<NRTThreadedNormalizeClient>::dump("Normalize", argv[1]);
   return 0;
 }

--- a/src/clients/PCA/PCA.cpp
+++ b/src/clients/PCA/PCA.cpp
@@ -4,6 +4,6 @@ int main(int argc, char *argv[]) {
   using namespace fluid::client;
   if (!argc) std::cerr << "Please pass a folder to write to";
   std::cout << "Write JSON to " << argv[1];
-  ParameterDump<RTPCAClient>::dump("PCA", argv[1]);
+  ParameterDump<NRTThreadedPCAClient>::dump("PCA", argv[1]);
   return 0;
 }

--- a/src/clients/RobustScale/RobustScale.cpp
+++ b/src/clients/RobustScale/RobustScale.cpp
@@ -4,6 +4,6 @@ int main(int argc, char *argv[]) {
   using namespace fluid::client;
   if (!argc) std::cerr << "Please pass a folder to write to";
   std::cout << "Write JSON to " << argv[1];
-  ParameterDump<RTRobustScaleClient>::dump("RobustScale", argv[1]);
+  ParameterDump<NRTThreadedRobustScaleClient>::dump("RobustScale", argv[1]);
   return 0;
 }

--- a/src/clients/Standardize/Standardize.cpp
+++ b/src/clients/Standardize/Standardize.cpp
@@ -4,6 +4,6 @@ int main(int argc, char *argv[]) {
   using namespace fluid::client;
   if (!argc) std::cerr << "Please pass a folder to write to";
   std::cout << "Write JSON to " << argv[1];
-  ParameterDump<RTStandardizeClient>::dump("Standardize", argv[1]);
+  ParameterDump<NRTThreadedStandardizeClient>::dump("Standardize", argv[1]);
   return 0;
 }

--- a/src/clients/UMAP/UMAP.cpp
+++ b/src/clients/UMAP/UMAP.cpp
@@ -4,6 +4,6 @@ int main(int argc, char *argv[]) {
   using namespace fluid::client;
   if (!argc) std::cerr << "Please pass a folder to write to";
   std::cout << "Write JSON to " << argv[1];
-  ParameterDump<RTUMAPClient>::dump("UMAP", argv[1]);
+  ParameterDump<NRTThreadedUMAPClient>::dump("UMAP", argv[1]);
   return 0;
 }


### PR DESCRIPTION
Supporting https://github.com/flucoma/flucoma-core/pull/35

Just updates to the class names in the .cpp stubs. Definitely just a squash merge if / when it happens. 

