### PR TITLE
KDTree Description

### DIFF
--- a/doc/KDTree.yaml
+++ b/doc/KDTree.yaml
@@ -13,8 +13,6 @@ see-also:
 description: |
   A K-Dimensional tree for efficient neighbourhood searches of multi-dimensional data.
 
-  See https://scikit-learn.org/stable/modules/neighbors.html#nearest-neighbor-algorithms for more on KD Trees
-
 parameters:
   numNeighbours:
     description: |


### PR DESCRIPTION
This removes the sklearn link fom the kdtree documentation.

The link is not only unclickable in many environments, but it should be shifted to higher level discussion on the learn.

This change is consistent with discussions we had _before_ Basel about how the documentation granularity should be shifted.﻿
