### PR TITLE
Don't bake in the architecture for apple

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ cmake_minimum_required(VERSION 3.11)
 cmake_policy(SET CMP0074 NEW) 
 
 if (APPLE)
-	set(CMAKE_OSX_ARCHITECTURES x86_64)
   set(CMAKE_XCODE_GENERATE_SCHEME ON)
   set(CMAKE_OSX_DEPLOYMENT_TARGET 10.8)
 endif()


### PR DESCRIPTION
@jamesb93 does this fix the M1 build for you? 

One source of complication might be that if your CMake is x64 then it might try and set the arch to that (but passing directly to CMake should fix this...) 