### PR TITLE
sc folder structure: Classes & Guides

### DIFF
--- a/flucoma/doc/cli/driver.py
+++ b/flucoma/doc/cli/driver.py
@@ -15,64 +15,64 @@ from .. transformers import default_transform
 from docutils import nodes
 
 '''
-CLI driver file 
+CLI driver file
 '''
 
 def buffer_reference_role(role, rawtext, text, lineno, inliner,
                            options={}, content=[]):
     '''
-    Not yet used 
-    
+    Not yet used
+
     docutils Role for substituting the correct string in place of 'buffer' in reST docs
-    '''                       
+    '''
     return 'file'
 
 def cli_visit_flucoma_reference(self, node, data, transform_name):
     '''
-    docutils Translator visit function for rendering links to FluCoMa objects in the CLI docs 
+    docutils Translator visit function for rendering links to FluCoMa objects in the CLI docs
     '''
     if transform_name:
         if(node.astext()) in data:
-            name = cli_object_namer(data[node.astext()]) 
-        else: 
+            name = cli_object_namer(data[node.astext()])
+        else:
             name = f'Unresolved lookup ({node.astext()})'
-    else: 
+    else:
         name = node.astext()
     attrs = {'href': name + '.html'}
     node[:] = [nodes.raw('',name, format='html')]
     self.body.append(self.starttag(node, 'a','',**attrs))
-    
+
 def cli_depart_flucoma_reference(self, node, data):
     '''
     closes the link opened by `cli_visit_flucoma_reference`
-    
+
     perhaps this is surplus to requirements because we know (?) that the link content isn't going to have any extra markup, so we could just close in `visit` by raising `SkipNode`
     '''
     self.body.append('</a>')
 
-def cli_object_namer(data):    
+def cli_object_namer(data):
     '''
     returns a properly formatted name for the CLI object, given the stub, e.g. `BufHPSS` beccomes `fluid-hpss`
-    
+
     nb the CLI only uses Buf* objects
     '''
     return f"fluid-{data['client_name'].lower().split('buf')[1]}"
 
 def cli_jinja_parameter_link(name,bits):
     '''
-    not yet used? 
-    
-    renders a reST link to a parameter as html `<code>`. 
-    
-    todo: This could be turned into an actual link if we rendered anchors around parameter and message definitions 
-    ''' 
+    not yet used?
+
+    renders a reST link to a parameter as html `<code>`.
+
+    todo: This could be turned into an actual link if we rendered anchors around parameter and message definitions
+    '''
     return f"<code>{name.lower()}</code>"
 
-def cli_type_map(type):    
+def cli_type_map(type):
     '''
     map types from generated JSON to 'types' for rendered HTML
-    
-    will throw KeyError if an unown type is passed in 
+
+    will throw KeyError if an unown type is passed in
     '''
     return {
         'float':'number',
@@ -80,12 +80,12 @@ def cli_type_map(type):
         'buffer':'symbol',
         'integer': 'int',
         'string': 'symbol',
-        'enum':'int', 
+        'enum':'int',
         'fft': 'int',
         'dataset':'symbol',
         'labelset':'symbol'
     }[type]
-    
+
 def transform_data(client, data):
     '''
     post-merge processing for data. defers to function in flucoma.doc.legacy that reproduces pre-refactor behaviour
@@ -95,23 +95,24 @@ def transform_data(client, data):
 '''
 
 '''
-settings = {   
-    'namer':cli_object_namer,     
-    'template': 'cli_htmlref.html',    
+settings = {
+    'namer':cli_object_namer,
+    'template': 'cli_htmlref.html',
     'extension': 'html',
     'types': cli_type_map,
-    'glob': '**/Buf*.json', 
+    'glob': '**/Buf*.json',
     'glob_filter': lambda x: re.match('Buf(?!Compose).*',x.stem) is not None,
-    'parameter_link': cli_jinja_parameter_link, 
+    'parameter_link': cli_jinja_parameter_link,
     'write_cross_ref': (cli_visit_flucoma_reference,cli_depart_flucoma_reference),
-    'code_block': '<code>{}</code>', 
-    'writer': FluidHTMLWriter, 
+    'code_block': '<code>{}</code>',
+    'writer': FluidHTMLWriter,
     'rst_render': rst_filter,
     'topic_extension':'html',
     'topic_subdir': '',
+    'client_subdir': '',
     'topic_template':'cli_htmltopic.html',
-    'transform': transform_data, 
-    'post': None, 
-    'defaults': None, 
+    'transform': transform_data,
+    'post': None,
+    'defaults': None,
     'buffer-string':'file'
 }

--- a/flucoma/doc/max/driver.py
+++ b/flucoma/doc/max/driver.py
@@ -21,31 +21,31 @@ def buffer_reference_role(role, rawtext, text, lineno, inliner,
 def max_visit_flucoma_reference(self, node, data, transform_name):
     if transform_name:
         if(node.astext()) in data:
-            name = max_object_namer(data[node.astext()]) 
-        else: 
+            name = max_object_namer(data[node.astext()])
+        else:
             name = f'Unresolved lookup ({node.astext()})'
-    else: 
+    else:
         name = node.astext()
-    
+
     node[:] = [nodes.raw('',name, format='html')]
     self.body.append(self.starttag(node, 'o'))
-    
+
 def max_depart_flucoma_reference(self, node, data):
     self.body.append('</o>')
-    
-def max_object_namer(data):    
-    tilde = '~' if not data['input_type'] == 'control' else ''
-    return f"fluid.{data['client_name'].lower()}{tilde}"    
 
-def max_type_map(type):       
-    
+def max_object_namer(data):
+    tilde = '~' if not data['input_type'] == 'control' else ''
+    return f"fluid.{data['client_name'].lower()}{tilde}"
+
+def max_type_map(type):
+
     return {
         'float':'float64',
         'long': 'int',
         'buffer':'symbol',
         'integer': 'int',
         'string': 'symbol',
-        'enum':'int', 
+        'enum':'int',
         'fft': 'int',
         'dataset':'symbol',
         'labelset':'symbol'
@@ -59,18 +59,18 @@ def max_jinja_parameter_link(name,data):
     return f'<at>{name.lower()}</at>'
 
 def write_max_indices(idx,program_args):
-    
+
     path = program_args.output_path / '../interfaces'
     path.mkdir(exist_ok=True)
-    
+
     maxdb_objs = {'maxdb':{'externals':{}}}
     qlookup = {}
-    
+
     for client,data in idx.items():
 
         maxname = max_object_namer(data)
-        
-        if 'messages' in data: 
+
+        if 'messages' in data:
             if 'dump' in data['messages']:
                 maxdb_objs['maxdb']['externals'][maxname]={
                     'object':'fluid.libmanipulation',
@@ -80,33 +80,33 @@ def write_max_indices(idx,program_args):
         qlookup[maxname] = {
             'digest': data['digest'],'category':['Fluid Corpus Manuipulation']
         }
-    
+
     maxdbfile = path / 'max.db.json'
     with open(maxdbfile,'w') as f:
         json.dump(maxdb_objs,f,sort_keys=True, indent=4)
     qlookup_file = path / 'flucoma-obj-qlookup.json'
-    with open(qlookup_file,'w') as f: 
+    with open(qlookup_file,'w') as f:
         json.dump(qlookup,f,sort_keys=True, indent=4)
 
 
-settings = {   
-    'namer':max_object_namer,     
+settings = {
+    'namer':max_object_namer,
     'template': 'maxref.xml',
     'extension': 'maxref.xml',
     'types': max_type_map,
-    'glob': '**/*.json', 
-    'parameter_link': max_jinja_parameter_link, 
-    'code_block': '<m>{}</m>', 
-    'writer': FluidHTMLWriter, 
+    'glob': '**/*.json',
+    'parameter_link': max_jinja_parameter_link,
+    'code_block': '<m>{}</m>',
+    'writer': FluidHTMLWriter,
     'rst_render': rst_filter,
-    'write_cross_ref': (max_visit_flucoma_reference,    
+    'write_cross_ref': (max_visit_flucoma_reference,
                         max_depart_flucoma_reference),
-    'topic_extension': 'maxvig.xml', 
+    'topic_extension': 'maxvig.xml',
     'topic_subdir': 'vignettes',
+    'client_subdir': '',
     'topic_template':'maxvig.xml',
-    'transform': transform_data, 
-    'post': write_max_indices, 
-    'defaults': defaults, 
+    'transform': transform_data,
+    'post': write_max_indices,
+    'defaults': defaults,
     'buffer-string':'<o>buffer~</o>'
 }
-     

--- a/flucoma/doc/pd/driver.py
+++ b/flucoma/doc/pd/driver.py
@@ -20,12 +20,12 @@ def buffer_reference_role(role, rawtext, text, lineno, inliner,
     return 'array'
 
 # class PDHTMLTranslator(html4css1.HTMLTranslator):
-#     """docutils translator for PD ref    
-#     """    
-#     def visit_reference(self,node):    
-#         atts = {'class' : 'fluid_object'}    
+#     """docutils translator for PD ref
+#     """
+#     def visit_reference(self,node):
+#         atts = {'class' : 'fluid_object'}
 #         if('flucoma' in node):
-#             pdname = pd_object_namer(node.astext())  
+#             pdname = pd_object_namer(node.astext())
 #             node[:] = [nodes.raw('',pdname,format='html')]
 #             atts['href'] = pdname + '.html'
 #             self.body.append(self.starttag(node, 'a', '',**atts))
@@ -37,65 +37,66 @@ def buffer_reference_role(role, rawtext, text, lineno, inliner,
 def pd_visit_flucoma_reference(self, node, data, transform_name):
     if transform_name:
         if(node.astext()) in data:
-            name = pd_object_namer(data[node.astext()]) 
-        else: 
+            name = pd_object_namer(data[node.astext()])
+        else:
             name = f'Unresolved lookup ({node.astext()})'
-    else: 
+    else:
         name = node.astext()
     attrs = {'href': name + '.html'}
     node[:] = [nodes.raw('',name, format='html')]
     self.body.append(self.starttag(node, 'a','',**attrs))
-    
+
 def pd_depart_flucoma_reference(self, node, data):
     self.body.append('</a>')
 
 
-def pd_object_namer(data):    
+def pd_object_namer(data):
     tilde = '~' if not data['client_name'].startswith('Buf') else ''
-    return f"fluid.{data['client_name'].lower()}{tilde}"    
+    return f"fluid.{data['client_name'].lower()}{tilde}"
 
 
-def pd_jinja_parameter_link(name,bits): 
+def pd_jinja_parameter_link(name,bits):
     return f"<code>{name.lower()}</code>"
 
-def pd_type_map(type):    
+def pd_type_map(type):
     return {
         'float':'number',
         'long': 'number',
         'buffer':'symbol',
         'integer': 'int',
         'string': 'symbol',
-        'enum':'int', 
+        'enum':'int',
         'fft': 'int',
         'dataset':'symbol',
         'labelset':'symbol'
     }[type]
-    
+
 def transform_data(client, data):
-    
+
     res = default_transform(client, data)
-    
+
     res.get('messages',{}).pop('dump', None)
     res.get('messages',{}).pop('load', None)
-    
+
     return res
 
-settings = {   
-    'namer':pd_object_namer,     
+settings = {
+    'namer':pd_object_namer,
     'template': 'pd_htmlref.html',
     'extension': 'html',
     'types': pd_type_map,
-    'glob': '**/*.json', 
-    'parameter_link': pd_jinja_parameter_link, 
+    'glob': '**/*.json',
+    'parameter_link': pd_jinja_parameter_link,
     'write_cross_ref': (pd_visit_flucoma_reference,pd_depart_flucoma_reference),
-    'code_block': '<m>{}</m>', 
+    'code_block': '<m>{}</m>',
     'writer': FluidHTMLWriter,
     'rst_render': rst_filter,
-    'topic_extension': 'html', 
+    'topic_extension': 'html',
     'topic_subdir': '',
+    'client_subdir': '',
     'topic_template':'pd_htmltopic.html',
-    'transform': transform_data, 
-    'post': None, 
+    'transform': transform_data,
+    'post': None,
     'defaults': defaults,
     'buffer-string': 'array'
 }

--- a/flucoma/doc/render.py
+++ b/flucoma/doc/render.py
@@ -18,9 +18,9 @@ from flucoma.doc.rst.docutils import register_custom_roles
 from .logger import ContextView,add_context
 
 def type_map(x,namer):
-    try: 
+    try:
         return namer(x)
-    except KeyError: 
+    except KeyError:
         return f'Unknown Type ({x})'
 
 def setup_docutils(client_index, args, driver):
@@ -28,7 +28,7 @@ def setup_docutils(client_index, args, driver):
 setup_docutils(None,None,None)
 
 def setup_jinja(client_index, args, driver):
-    
+
     examples_path = (args.yaml_path.resolve() / '../example-code' / args.host).resolve()
     e = Environment(
     loader = FileSystemLoader([args.template_path, examples_path]),
@@ -42,66 +42,65 @@ def setup_jinja(client_index, args, driver):
     e.filters['rst'] = driver['rst_render']
     e.filters['as_host_object_name'] = lambda x: driver['namer'](client_index[x]) if x in client_index else f'Unresolved lookup ({x})'
     e.filters['typename'] = partial(type_map, namer=driver['types'])
-    e.filters['constraints'] = lambda x,y,z: ''     
-    e.filters['lookup'] = lambda x: client_index[x] if x in client_index else ''       
-    
+    e.filters['constraints'] = lambda x,y,z: ''
+    e.filters['lookup'] = lambda x: client_index[x] if x in client_index else ''
+
     e.filters['include_raw'] = lambda name: Markup(e.loader.get_source(e,name)[0])
-    
+
     e.tests['incli'] = lambda s: s.lower().startswith('buf')
-    
-    if('jinja_extra' in driver): 
+
+    if('jinja_extra' in driver):
         driver['jinja_extra'](e, client_index, args)
-    
-    return e 
-    
-def client(client, client_index, args, driver):        
+
+    return e
+
+def client(client, client_index, args, driver):
     outputdir = args.output_path
     client_data = client_index[client]
-    
-    ofile = outputdir / f"{driver['namer'](client_data)}.{driver['extension']}"
-    
-    env = setup_jinja(client_index, args, driver)    
-    
+
+    ofile = outputdir / f"{Path(driver['client_subdir']) / driver['namer'](client_data)}.{driver['extension']}"
+
+    (outputdir / Path(driver['client_subdir'])).mkdir(exist_ok=True)
+
+    env = setup_jinja(client_index, args, driver)
+
     template_string = driver['template'](client_data) if isinstance(driver['template'],Callable) else driver['template']
-    
-    
+
     template = env.get_template(template_string)
     logging.info(f'{client}: Making {ofile}')
-    
+
     client_data['attributes'] = ContextView(client_data.pop('attributes'))
     client_data['arguments'] = ContextView(client_data.pop('arguments'))
     client_data['messages'] =  ContextView(client_data.pop('messages'))
-    
+
     with add_context(client):
         with open(ofile,'w') as f:
-            f.write(template.render(client_data, 
-                                    index=client_index, 
-                                    driver = driver 
+            f.write(template.render(client_data,
+                                    index=client_index,
+                                    driver = driver
                                     )
-                    )            
-            
-        return client_data; 
+                    )
+
+        return client_data;
 
 def topic(topic_data,client_index,args,driver):
-    
+
     outputdir = args.output_path
-    ofile = outputdir / f"{Path(driver['topic_subdir']) /topic_data['name']}.{driver['topic_extension']}"
-    
+    ofile = outputdir / f"{Path(driver['topic_subdir']) / topic_data['name']}.{driver['topic_extension']}"
+
     (outputdir / Path(driver['topic_subdir'])).mkdir(exist_ok=True)
-        
-    env = setup_jinja(client_index, args, driver) 
+
+    env = setup_jinja(client_index, args, driver)
     template = env.get_template(driver['topic_template'])
     logging.info(f"{topic_data['name']}: Making {ofile}")
-    
+
     with open(ofile,'w') as f:
         f.write(template.render(
             title=topic_data['title'],
             digest=topic_data['digest'],
             description=topic_data['description'],
-            index=client_index, 
-            driver = driver 
+            index=client_index,
+            driver = driver
         ))
-        
+
     return topic_data
-    
-    

--- a/flucoma/doc/sc/driver.py
+++ b/flucoma/doc/sc/driver.py
@@ -18,33 +18,33 @@ def buffer_reference_role(role, rawtext, text, lineno, inliner,
 
 def sc_visit_flucoma_reference(self, node, data, transform_name):
     if transform_name:
-        if(node.astext()) in data:            
-            name = sc_object_namer(data[node.astext()]) 
-        else: 
+        if(node.astext()) in data:
+            name = sc_object_namer(data[node.astext()])
+        else:
             name = f'Unresolved lookup ({node.astext()})'
-    else: 
+    else:
         name = node.astext()
 
     self.body.append(f"LINK::Classes/{name}::")
-    raise nodes.SkipNode 
-    
+    raise nodes.SkipNode
+
 def sc_depart_flucoma_reference(self, node, data):
     pass
 
-def sc_object_namer(data):    
-    return f"Fluid{data['client_name']}"    
+def sc_object_namer(data):
+    return f"Fluid{data['client_name']}"
 
-def sc_jinja_parameter_link(name,bits): 
+def sc_jinja_parameter_link(name,bits):
     return f"CODE::{name.lower()}::"
 
-def sc_type_map(type):    
+def sc_type_map(type):
     return {
         'float':'Float',
         'long': 'Integer',
         'buffer':'Buffer',
         'integer': 'Integer',
         'string': 'Symbol',
-        'enum':'Integer', 
+        'enum':'Integer',
         'fft': 'Integer',
         'dataset':'FluidDataSet',
         'labelset':'FluidLabelSet'
@@ -52,58 +52,59 @@ def sc_type_map(type):
 
 
 def sc_transform_data(object_name,data):
-    data['client_name'] = object_name 
+    data['client_name'] = object_name
     data['category'] = []
     data['keywords'] = []
-    data['module'] = ''        
-    data['discussion'] = data.pop('discussion','')             
+    data['module'] = ''
+    data['discussion'] = data.pop('discussion','')
 
     seealso = [f'Classes/Fluid{x}' for x in tidy_split(data.pop('see-also',''))]
     seealso.extend(tidy_split(data.pop('sc-related','')))
     data['seealso'] = ','.join(seealso)
     data['sc_category'] = data.pop('sc-category','')
-    
+
     data['sc_code'] = data.pop('sc-code','')
-    
-    params = {x['name']:x for x in data.pop('parameters')}         
-    
+
+    params = {x['name']:x for x in data.pop('parameters')}
+
     data['attributes'] = OrderedDict(
-        (filter_fixed_controls(params,fixed=False))    
+        (filter_fixed_controls(params,fixed=False))
     )
 
     data['arguments'] = OrderedDict(
-        filter_fixed_controls(params,fixed=True) 
+        filter_fixed_controls(params,fixed=True)
     )
-    
+
     data['messages'] = {x['name']:x for x in data.pop('messages')}
-    
-    for n,m in data['messages'].items(): 
+
+    for n,m in data['messages'].items():
         m['args'] = {x['name']:x for x in m.pop('args')}
-    
+
     return data
 
 def choose_template(client_data):
     return f"schelp_{client_data['species']}.schelp"
 
-def configure_jinja(environment, client_index, args):    
+def configure_jinja(environment, client_index, args):
     environment.filters['example_code'] = lambda name: f'{name}.scd'
 
-settings = {   
-    'namer':sc_object_namer,     
+settings = {
+    'namer':sc_object_namer,
     'template': choose_template,
     'extension': 'schelp',
     'types': sc_type_map,
-    'glob': '**/*.json', 
-    'parameter_link': sc_jinja_parameter_link, 
+    'glob': '**/*.json',
+    'parameter_link': sc_jinja_parameter_link,
     # 'write_cross_ref': (sc_visit_flucoma_reference,sc_depart_flucoma_reference),
-    'code_block': 'code::{}::', 
-    'writer': SCDocWriter, 
+    'code_block': 'code::{}::',
+    'writer': SCDocWriter,
     'rst_render': rst_filter,
-    'topic_extension': 'schelp', 
-    'topic_subdir': 'guides',
+    'topic_extension': 'schelp',
+    'topic_subdir': 'Guides',
+    'client_subdir': 'Classes',
     'topic_template':'schelp_topic.schelp',
-    'transform': sc_transform_data, 
-    'post': None, 
-    'defaults': defaults, 
+    'transform': sc_transform_data,
+    'post': None,
+    'defaults': defaults,
     'jinja_extra': configure_jinja
 }


### PR DESCRIPTION
This changes the `render.py` client function to look for a 'client_subdir' in the driver's `settings` dict, which allows the SuperCollider docs to be rendered into two folders inside of the master `outputdir`: (Classes for the 'clients' & Guides for the 'topics').

I've also added to the `pd`, `cli`, and `max` drivers the entry in the `settings` dict: `'client_subdir': ''` so that they will render as they were previously.

I tested it on all four and SC looks correctly changed and the other three look as they did before.