### PR TITLE
Fix SC fft settings and  padding parameters

### DIFF
--- a/flucoma/doc/sc/driver.py
+++ b/flucoma/doc/sc/driver.py
@@ -71,6 +71,20 @@ def sc_transform_data(object_name,data):
         (filter_fixed_controls(params,fixed=False))    
     )
 
+    fftSettings = data['attributes'].pop('fftSettings',None) 
+    if fftSettings: 
+        data['attributes'] = {
+            **data['attributes'],
+            'windowSize': fftSettings['win'], 
+            'hopSize': fftSettings['hop'], 
+            'fftSize':  fftSettings['fft']
+        }
+    
+    # move 'padding to end'
+    padding = data['attributes'].pop('padding',None)    
+    if padding:
+        data['attributes'] = {**data['attributes'], 'padding': padding}
+
     data['arguments'] = OrderedDict(
         filter_fixed_controls(params,fixed=True) 
     )


### PR DESCRIPTION
* FFT settings needed to be disaggregated into win, hop, fft. A remaining todo is how to have SC, Max and PD still use the same basic doc. At the moment we have duplication (SC is taken from the YAML now) 
* `padding` needed to be moved to the end of the parameter list (fixes #43)