### PR TITLE
added arg 'in' to species: transformer template

### DIFF
--- a/doc/NMFMorph.yaml
+++ b/doc/NMFMorph.yaml
@@ -7,7 +7,7 @@
 # (grant agreement No 725899).
 ---
 digest: Morph between sounds
-species: transformer
+species: buffer-transformer
 sc-categories: FluidCorpusManipulation
 sc-related: Classes/FluidAudioTransport, Classes/FluidBufNMFCross
 see-also: 

--- a/flucoma/doc/templates/schelp_buffer-transformer.schelp
+++ b/flucoma/doc/templates/schelp_buffer-transformer.schelp
@@ -1,0 +1,8 @@
+{% extends "schelp_base.schelp" %}
+{% block classmethods %}
+CLASSMETHODS::
+
+METHOD:: ar
+
+{% include "schelp_controls.schelp" %}
+{% endblock %}

--- a/flucoma/doc/templates/schelp_transformer.schelp
+++ b/flucoma/doc/templates/schelp_transformer.schelp
@@ -4,5 +4,8 @@ CLASSMETHODS::
 
 METHOD:: ar
 
+ARGUMENT:: in
+The audio to be processed.
+
 {% include "schelp_controls.schelp" %}
 {% endblock %}


### PR DESCRIPTION
All of the objects of species: transformer were missing the `in` argument in their documentation. I added it to the template for this species and all seems good. If you approve, please merge.