### PR TITLE
[SC] FluidBufSTFT: max 1024 chans text in help file

### DIFF
--- a/doc/BufSTFT.yaml
+++ b/doc/BufSTFT.yaml
@@ -18,7 +18,7 @@ description: |
 
   The object is restricted to analysing a single source channel, because the channel counts of the magntude and phase buffers would quickly get out of hand otherwise.
 
-scdescription: |
+sc-description: |
   If using an fftSize > 1024 the number of channels in the magnitude and phase buffers will be > 1024, which is the maximum number of channels a buffer can have when using |buffer|'s instance method code::.loadToFloatArray::. This means you won't be able to get the values from the buffer using code::.loadToFloatArray::. Instead you can use |buffer|'s instance method code::.getToFloatArray::.
 parameters:
   source:

--- a/doc/BufSTFT.yaml
+++ b/doc/BufSTFT.yaml
@@ -18,6 +18,8 @@ description: |
 
   The object is restricted to analysing a single source channel, because the channel counts of the magntude and phase buffers would quickly get out of hand otherwise.
 
+scdescription: |
+  If using an fftSize > 1024 the number of channels in the magnitude and phase buffers will be > 1024, which is the maximum number of channels a buffer can have when using |buffer|'s instance method code::.loadToFloatArray::. This means you won't be able to get the values from the buffer using code::.loadToFloatArray::. Instead you can use |buffer|'s instance method code::.getToFloatArray::.
 parameters:
   source:
     description: |

--- a/flucoma/doc/sc/driver.py
+++ b/flucoma/doc/sc/driver.py
@@ -66,6 +66,7 @@ def sc_transform_data(object_name,data):
     data['seealso'] = ','.join(seealso)
     data['sc_category'] = data.pop('sc-category','')
     
+    data['sc_description'] = data.pop('sc-description','')
     data['sc_code'] = data.pop('sc-code','')
     
     params = {x['name']:x for x in data.pop('parameters')}         

--- a/flucoma/doc/templates/schelp_base.schelp
+++ b/flucoma/doc/templates/schelp_base.schelp
@@ -8,6 +8,8 @@ DESCRIPTION::
 
 {{ discussion | rst | indent(first=True) }}
 
+{{ scdescription | rst | indent(first=True) }}
+
 {% block classmethods %}
 CLASSMETHODS::
 {% endblock %}

--- a/flucoma/doc/templates/schelp_base.schelp
+++ b/flucoma/doc/templates/schelp_base.schelp
@@ -8,7 +8,7 @@ DESCRIPTION::
 
 {{ discussion | rst | indent(first=True) }}
 
-{{ scdescription | rst | indent(first=True) }}
+{{ sc_description | rst | indent(first=True) }}
 
 {% block classmethods %}
 CLASSMETHODS::


### PR DESCRIPTION
The text explaining that `.loadToFloatArray` doesn't work with > 1024 channels has been added to the FluidBufSTFT help file. It also explains that `.getToFloatArray` is what the user should do.

In order for this text to show up in SC only I've added a field to the YAML "sc-description" (with approval from @weefuzzy)

If acceptable to @weefuzzy, please merge!