### PR TITLE
BufAudioTransport now has A-B based arguments

### DIFF
--- a/doc/BufAudioTransport.yaml
+++ b/doc/BufAudioTransport.yaml
@@ -17,34 +17,34 @@ description: |
   See Henderson and Solomonm (2019) AUDIO TRANSPORT: A GENERALIZED PORTAMENTO VIA OPTIMAL TRANSPORT, DaFx
 
 parameters:
-  source1:
+  sourceA:
     description: |
       The first source buffer
-  startFrame1:
+  startFrameA:
     description: |
       offset into the first source buffer (samples)
-  numFrames1:
+  numFramesA:
     description: |
       number of samples to use from first source buffer
-  startChan1:
+  startChanA:
     description: |
       starting channel of first source buffer
-  numChans1:
+  numChansA:
     description: |
       number of channels to process in first source buffer
-  source2:
+  sourceB:
     description: |
       the second source buffer
-  startFrame2:
+  startFrameB:
     description: |
       offset into the second source buffer (samples)
-  numFrames2:
+  numFramesB:
     description: |
       number of samples to process from second buffer
-  startChan2:
+  startChanB:
     description: |
       starting channel for second buffer
-  numChans2:
+  numChansB:
     description: |
       number of channels to process in second buffer
   destination:


### PR DESCRIPTION
Because this affects (at least) 3 of our repos, I thought it would be good to get everyone's eyes over it!

This converts BufAudioTransport's arguments to an A/B based system for the two input buffers. I tested this and it all seems to be working great.

In response to: https://github.com/flucoma/flucoma-docs/issues/66
Parallel to: 
* https://github.com/flucoma/flucoma-sc/pull/62
* https://github.com/flucoma/flucoma-core/pull/89

<img width="514" alt="Screenshot 2022-02-07 at 15 19 29" src="https://user-images.githubusercontent.com/1531144/152865155-8eff2d4c-7898-4f6b-869d-01eccc5a701d.png">