### PR TITLE
[Enhance] Add CCE specific see also sections to transformer and template

### DIFF
--- a/doc/Pitch.yaml
+++ b/doc/Pitch.yaml
@@ -11,6 +11,8 @@ species: descriptor
 sc-categories: Libraries>FluidDecomposition
 sc-related: Guides/FluidCorpusManipulationToolkit, Classes/Pitch
 see-also: BufPitch, MFCC, MelBands, Loudness, SpectralShape
+max-seealso: fzero~, retune~
+pd-seealso: sigmund~
 description: Three popular pitch descriptors, computed as frequency and the confidence in its value.
 discussion: The process will return a multichannel control steam with [pitch, confidence] values, which will be repeated if no change happens within the algorithm, i.e. when the hopSize is larger than the signal vector size. A pitch of 0 Hz is yield (or -999.0 when the unit is in MIDI note) when the algorithm cannot find a fundamental at all.
 process: The audio rate in, control rate out version of the object.

--- a/doc/Pitch.yaml
+++ b/doc/Pitch.yaml
@@ -11,8 +11,6 @@ species: descriptor
 sc-categories: Libraries>FluidDecomposition
 sc-related: Guides/FluidCorpusManipulationToolkit, Classes/Pitch
 see-also: BufPitch, MFCC, MelBands, Loudness, SpectralShape
-max-seealso: fzero~, retune~
-pd-seealso: sigmund~
 description: Three popular pitch descriptors, computed as frequency and the confidence in its value.
 discussion: The process will return a multichannel control steam with [pitch, confidence] values, which will be repeated if no change happens within the algorithm, i.e. when the hopSize is larger than the signal vector size. A pitch of 0 Hz is yield (or -999.0 when the unit is in MIDI note) when the algorithm cannot find a fundamental at all.
 process: The audio rate in, control rate out version of the object.

--- a/flucoma/doc/templates/maxref.xml
+++ b/flucoma/doc/templates/maxref.xml
@@ -164,5 +164,8 @@ under the European Union’s Horizon 2020 research and innovation programme
 	<seealsolist>
     {% for s in seealso %}
     <seealso name='{{ s | as_host_object_name }}' />{% endfor %}
+    {% for s in max_seealso %}
+    <seealso name='{{ s }}' /> 
+    {% endfor %}
 	</seealsolist>
 </c74object>

--- a/flucoma/doc/templates/pd_htmlref.html
+++ b/flucoma/doc/templates/pd_htmlref.html
@@ -137,6 +137,10 @@ under the European Union’s Horizon 2020 research and innovation programme
     {%-for s in seealso -%}
     <h3 class="seealso_name"><a href="{{ s | as_host_object_name }}.html">{{ s }}</a></h3>    
     {%- endfor -%}
+
+    {%-for s in pd_seealso -%}
+    <h3 class="seealso_name"><a href="{{ s }}.html">{{ s }}</a></h3>    
+    {%- endfor -%}
   </section> 
 </body>
 </html>

--- a/flucoma/doc/templates/pd_htmlref.html
+++ b/flucoma/doc/templates/pd_htmlref.html
@@ -139,7 +139,7 @@ under the European Union’s Horizon 2020 research and innovation programme
     {%- endfor -%}
 
     {%-for s in pd_seealso -%}
-    <h3 class="seealso_name"><a href="{{ s }}.html">{{ s }}</a></h3>    
+    <h3 class="seealso_name">{{ s }}</h3>    
     {%- endfor -%}
   </section> 
 </body>

--- a/flucoma/doc/transformers.py
+++ b/flucoma/doc/transformers.py
@@ -36,7 +36,19 @@ def default_transform(object_name, data):
     data['discussion'] = data.pop('discussion','') 
 
     data['seealso'] = [x for x in tidy_split(data.pop('see-also',''))]
-    
+
+    try:
+        data['max_seealso'] = data['max-seealso'].split(',')
+    except (KeyError, AttributeError):
+        data['max_seealso'] = ['']
+        print(f'WARNING: No "max-seealso" for {object_name}. Inserting blank placeholder')
+
+    try:
+        data['pd_seealso'] = data['pd-seealso'].split(',')
+    except (KeyError, AttributeError):
+        data['pd_seealso'] = ['']
+        print(f'WARNING: No "pd-seealso" for {object_name}. Inserting blank placeholder')
+
     data['parameters'].append({
         'name':'warnings',
         'constraints': {'max': 1, 'min': 0},

--- a/flucoma/doc/transformers.py
+++ b/flucoma/doc/transformers.py
@@ -6,6 +6,8 @@
 # under the European Union’s Horizon 2020 research and innovation programme
 # (grant agreement No 725899).
 
+import logging
+from flucoma.doc import logger
 from collections import OrderedDict
 
 """
@@ -37,17 +39,12 @@ def default_transform(object_name, data):
 
     data['seealso'] = [x for x in tidy_split(data.pop('see-also',''))]
 
-    try:
-        data['max_seealso'] = data['max-seealso'].split(',')
-    except (KeyError, AttributeError):
-        data['max_seealso'] = ['']
-        print(f'WARNING: No "max-seealso" for {object_name}. Inserting blank placeholder')
-
-    try:
-        data['pd_seealso'] = data['pd-seealso'].split(',')
-    except (KeyError, AttributeError):
-        data['pd_seealso'] = ['']
-        print(f'WARNING: No "pd-seealso" for {object_name}. Inserting blank placeholder')
+    with logger.add_context([object_name]): 
+        for k in ['max-seealso', 'pd-seealso']:    
+            if k in data: 
+                data[k.replace('-', '_')] = [x.strip() for x in data.get(k, '').split(',')]
+            else:
+                logging.warning(f"No {k} entry")
 
     data['parameters'].append({
         'name':'warnings',


### PR DESCRIPTION
This enables you to define:

```yaml
max-seealso: fzero~
pd-related: sigmund~
```

in the YAML docs which is then rendered in the appropriate templates.

I've opted for a relatively permissive `try/Except` block to catch cases where these new things are not defined or just not needed. It thusly throws a warning if they aren't which given the current unfinished state of the docs is a bit noisy.

On another note does this block up the YAML to RST milestone?