### PR TITLE
MelBands zeros warning

### DIFF
--- a/doc/BufMelBands.rst
+++ b/doc/BufMelBands.rst
@@ -9,6 +9,8 @@
 
    The process will return a single multichannel buffer of ``numBands`` per input channel. Each frame represents a value, which is every hopSize.
 
+   When using a high value for ``numBands``, you may end up with empty channels (filled with zeros) in the MelBands output. This is because there is not enough information in the FFT analysis to properly calculate values for every MelBand. Increasing the ``fftSize`` will ensure you have values for all the MelBands.
+
 :process: This is the method that calls for the spectral shape descriptors to be calculated on a given source buffer.
 :output: Nothing, as the destination buffer is declared in the function call.
 

--- a/doc/MelBands.rst
+++ b/doc/MelBands.rst
@@ -9,6 +9,8 @@
 
    The process will return a multichannel control steam of size maxNumBands, which will be repeated if no change happens within the algorithm, i.e. when the hopSize is larger than the signal vector size.
 
+   When using a high value for ``numBands``, you may end up with empty channels (filled with zeros) in the MelBands output. This is because there is not enough information in the FFT analysis to properly calculate values for every MelBand. Increasing the ``fftSize`` will ensure you have values for all the MelBands.
+   
 :process: The audio rate in, control rate out version of the object.
 :output: A  KR signal of maxNumBands channels, giving the measure amplitudes for each band. The latency is windowSize.
 


### PR DESCRIPTION
In response to: https://github.com/flucoma/flucoma-core/issues/84

Please read the added text and provide comments or approve.

This adds an explanation into the documentation. It doesn't throw an issue when it happens (as was discussed in the issue).

I think this can happen for beta5 and having the `C++` throw a warning when it happens can be saved for later when that becomes possible.