### PR TITLE
[Enhance] Learn platform link generation

### DIFF
--- a/flucoma/doc/learn.py
+++ b/flucoma/doc/learn.py
@@ -1,0 +1,22 @@
+def derive_learn_link(object_name):
+    url_map = {
+        'bufampfeature' : 'ampfeature',
+        'bufnoveltyfeature' : 'noveltyfeature',
+        'bufonsetfeature' : 'onsetfeature',
+        'bufspectralshape' : 'spectralshape',
+        'bufchroma' : 'chroma',
+        'bufloudness' : 'loudness',
+        'bufmelbands' : 'melbands',
+        'bufmfcc' : 'mfcc',
+        'bufpitch' : 'pitch',
+        'bufhpss' : 'hpss',
+        'bufsines' : 'sines',
+        'buftransients' : 'transients',
+        'bufampgate' : 'ampgate',
+        'bufampslice' : 'ampslice',
+        'bufnoveltyslice' : 'noveltyslice',
+        'bufonsetslice' : 'onsetslice',
+        'buftransientslice' : 'transientslice',
+        'bufaudiotransport' : 'audiotransport'
+    }
+    return url_map.get(object_name.lower()) or object_name.lower()

--- a/flucoma/doc/sc/driver.py
+++ b/flucoma/doc/sc/driver.py
@@ -9,6 +9,7 @@
 from docutils import nodes
 from collections import OrderedDict
 from ..transformers import tidy_split, filter_fixed_controls
+from flucoma.doc.learn import derive_learn_link
 from flucoma.doc.rst.scdoc import SCDocWriter,rst_filter
 from .defaults import defaults
 import copy
@@ -55,6 +56,7 @@ def sc_type_map(type):
 
 def sc_transform_data(object_name,data):
     data['client_name'] = object_name 
+    data['learn_url'] = 'https://learn.flucoma.org/reference/' + derive_learn_link(object_name)
     data['category'] = []
     data['keywords'] = []
     data['module'] = ''        

--- a/flucoma/doc/templates/cli_htmlref.html
+++ b/flucoma/doc/templates/cli_htmlref.html
@@ -35,6 +35,7 @@ under the European Union’s Horizon 2020 research and innovation programme
   <section class="object_discussion"> 
     <h2>Discussion</h2> 
     <p>{{ discussion|rst }}</p>
+    <p>Read more about {{ client_name | as_host_object_name }} on the <a href='{{ learn_url | e }}'>learn platform</a>.</p>
     <p>{{ client_name | as_host_object_name }} is part of the Fluid Decomposition Toolkit of the FluCoMa project. For more explanations, learning material, and discussions on its musicianly uses, visit <a href="http://www.flucoma.org/">flucoma.org</a>.</p>
   </section>
   <section class="attribute_section">

--- a/flucoma/doc/templates/maxref.xml
+++ b/flucoma/doc/templates/maxref.xml
@@ -14,10 +14,15 @@ under the European Union’s Horizon 2020 research and innovation programme
 	<digest>{{ digest }}</digest>
 	<description>{{ description | striprst }}</description>
   <discussion>
-      <h4><openfilelink filename="Fluid Corpus Manipulation Toolkit.maxpat">Open the Overview Patch</openfilelink></h4>
-        {{ discussion | rst | indent(8, first=True)}}
+    <h4><openfilelink filename="Fluid Corpus Manipulation Toolkit.maxpat">Open the Overview Patch</openfilelink></h4>
+    {{ discussion | rst | indent(8, first=True)}}
+    <p>
+    Read more about {{ client_name | as_host_object_name }} on the <a href='{{ "https://learn.flucoma.org/reference/"~learn_url | e }}'>learn platform</a>.
+    </p>
 
-		     {{ client_name | as_host_object_name }} is part of the Fluid Decomposition Toolkit of the FluCoMa project. For more explanations, learning material, and discussions on its musicianly uses, visit <a href="http://www.flucoma.org/">flucoma.org</a>.
+    <p>
+    {{ client_name | as_host_object_name }} is part of the Fluid Decomposition Toolkit of the FluCoMa project. For more explanations, learning material and discussions about FluCoMa visit <a href="http://www.flucoma.org/">flucoma.org</a>.
+    </p>
   </discussion>
 	<!--METADATA-->
 	<metadatalist>

--- a/flucoma/doc/templates/maxref.xml
+++ b/flucoma/doc/templates/maxref.xml
@@ -16,13 +16,8 @@ under the European Union’s Horizon 2020 research and innovation programme
   <discussion>
     <h4><openfilelink filename="Fluid Corpus Manipulation Toolkit.maxpat">Open the Overview Patch</openfilelink></h4>
     {{ discussion | rst | indent(8, first=True)}}
-    <p>
-    Read more about {{ client_name | as_host_object_name }} on the <a href='{{ "https://learn.flucoma.org/reference/"~learn_url | e }}'>learn platform</a>.
-    </p>
-
-    <p>
-    {{ client_name | as_host_object_name }} is part of the Fluid Decomposition Toolkit of the FluCoMa project. For more explanations, learning material and discussions about FluCoMa visit <a href="http://www.flucoma.org/">flucoma.org</a>.
-    </p>
+    <p>Read more about {{ client_name | as_host_object_name }} on the <a href='{{ learn_url | e }}'>learn platform</a>.</p>
+    <p>{{ client_name | as_host_object_name }} is part of the Fluid Decomposition Toolkit of the FluCoMa project. For more explanations, learning material, and discussions on its musicianly uses, visit <a href="http://www.flucoma.org/">flucoma.org</a>.</p>
   </discussion>
 	<!--METADATA-->
 	<metadatalist>

--- a/flucoma/doc/templates/pd_htmlref.html
+++ b/flucoma/doc/templates/pd_htmlref.html
@@ -33,6 +33,8 @@ under the European Union’s Horizon 2020 research and innovation programme
     <h2>Discussion</h2> 
     
     {{ discussion|rst }}
+
+    <p>Read more about {{ client_name | as_host_object_name }} on the <a href='{{ learn_url | e }}'>learn platform</a>.</p>
     
     <p>{{ client_name | as_host_object_name }} is part of the Fluid Decomposition Toolkit of the FluCoMa project. For more explanations, learning material, and discussions on its musicianly uses, visit <a href="http://www.flucoma.org/">flucoma.org</a>.</p>
   </section>

--- a/flucoma/doc/templates/schelp_base.schelp
+++ b/flucoma/doc/templates/schelp_base.schelp
@@ -8,6 +8,8 @@ DESCRIPTION::
 
 {{ discussion | rst | indent(first=True) }}
 
+Read more about {{ client_name | as_host_object_name }} on the link::{{learn_url}}##learn platform::.
+
 {% block classmethods %}
 CLASSMETHODS::
 {% endblock %}

--- a/flucoma/doc/transformers.py
+++ b/flucoma/doc/transformers.py
@@ -42,10 +42,34 @@ def tidy_split(string,separator=','):
     return map(lambda x: x.strip(),
         filter(lambda x: len(x), string.split(separator))
     )
+
+def derive_learn_link(object_name):
+    url_map = {
+        'bufampfeature' : 'ampfeature',
+        'bufnoveltyfeature' : 'noveltyfeature',
+        'bufonsetfeature' : 'onsetfeature',
+        'bufspectralshape' : 'spectralshape',
+        'bufchroma' : 'chroma',
+        'bufloudness' : 'loudness',
+        'bufmelbands' : 'melbands',
+        'bufmfcc' : 'mfcc',
+        'bufpitch' : 'pitch',
+        'bufhpss' : 'hpss',
+        'bufsines' : 'sines',
+        'buftransients' : 'transients',
+        'bufampgate' : 'ampgate',
+        'bufampslice' : 'ampslice',
+        'bufnoveltyslice' : 'noveltyslice',
+        'bufonsetslice' : 'onsetslice',
+        'buftransientslice' : 'transientslice',
+        'bufaudiotransport' : 'audiotransport'
+    }
+    return url_map.get(object_name.lower()) or object_name.lower()
  
 def default_transform(object_name, data):
     
     data['client_name'] = object_name 
+    data['learn_url'] = derive_learn_link(object_name)
     data['category'] = []
     data['keywords'] = []
     data['module'] = 'fluid decomposition'

--- a/flucoma/doc/transformers.py
+++ b/flucoma/doc/transformers.py
@@ -6,10 +6,11 @@
 # under the European Union’s Horizon 2020 research and innovation programme
 # (grant agreement No 725899).
 
+import copy
 import logging
+from flucoma.doc.learn import derive_learn_link
 from flucoma.doc import logger
 from collections import OrderedDict
-import copy
 from functools import reduce
 
 """
@@ -42,34 +43,10 @@ def tidy_split(string,separator=','):
     return map(lambda x: x.strip(),
         filter(lambda x: len(x), string.split(separator))
     )
-
-def derive_learn_link(object_name):
-    url_map = {
-        'bufampfeature' : 'ampfeature',
-        'bufnoveltyfeature' : 'noveltyfeature',
-        'bufonsetfeature' : 'onsetfeature',
-        'bufspectralshape' : 'spectralshape',
-        'bufchroma' : 'chroma',
-        'bufloudness' : 'loudness',
-        'bufmelbands' : 'melbands',
-        'bufmfcc' : 'mfcc',
-        'bufpitch' : 'pitch',
-        'bufhpss' : 'hpss',
-        'bufsines' : 'sines',
-        'buftransients' : 'transients',
-        'bufampgate' : 'ampgate',
-        'bufampslice' : 'ampslice',
-        'bufnoveltyslice' : 'noveltyslice',
-        'bufonsetslice' : 'onsetslice',
-        'buftransientslice' : 'transientslice',
-        'bufaudiotransport' : 'audiotransport'
-    }
-    return url_map.get(object_name.lower()) or object_name.lower()
  
 def default_transform(object_name, data):
-    
     data['client_name'] = object_name 
-    data['learn_url'] = derive_learn_link(object_name)
+    data['learn_url'] = 'https://learn.flucoma.org/reference/' + derive_learn_link(object_name)
     data['category'] = []
     data['keywords'] = []
     data['module'] = 'fluid decomposition'


### PR DESCRIPTION
This PR adds an additional bit of data in the relevant transformers so that learn links are generated in the discussion sections.

For objects that share a link (bufspectralshape/spectralshape both go to /reference/spectralshape) a dictionary is used and checked against. You can see this in the new file: learn.py

- update default transformer to handle learn links
- update maxref template to acount for learn link
- add link to templates discussion
- compartmentalise the learn link derivation
- update the supercollider driver which doesnt use default transform
