### PR TITLE
[fix] typos and errors

### DIFF
--- a/doc/AmpGate.rst
+++ b/doc/AmpGate.rst
@@ -3,7 +3,7 @@
 :sc-categories: Libraries>FluidDecomposition
 :sc-related: Guides/FluidCorpusManipulation
 :see-also: BufAmpGate, AmpSlice, OnsetSlice, NoveltySlice, TransientSlice
-:description: Absolute amplitude threshold gate detector on a real-time signal
+:description: Absolute amplitude threshold gate detector on a realtime signal
 
 :discussion: 
    AmpGate outputs a audio-rate, single-channel signal that is either 0, indicating the gate is closed, or 1, indicating the gate is open. The gate detects an onset (opens) when the internal envelope follower (controlled by ``rampUp`` and ``rampDown``) goes above a specified ``onThreshold`` (in dB) for at least ``minLengthAbove`` samples. The gate will stay open until the envelope follower goes below ``offThreshold`` (in dB) for at least ``minLengthBelow`` samples, which triggers an offset.

--- a/doc/AmpSlice.rst
+++ b/doc/AmpSlice.rst
@@ -34,7 +34,7 @@
 
 :control offThreshold:
 
-   The threshold in dB of the relative envelope follower to reset, aka to allow the differential envelop to trigger again.
+   The threshold in dB of the relative envelope follower to reset, aka to allow the differential envelope to trigger again.
 
 :control floor:
 

--- a/doc/AmpSlice.rst
+++ b/doc/AmpSlice.rst
@@ -5,7 +5,7 @@
 :see-also: BufAmpSlice, AmpGate, OnsetSlice, NoveltySlice, TransientSlice
 :description: Implements an amplitude-based slicer, with various customisable options and conditions to detect relative amplitude changes as onsets.
 :discussion: 
-   FluidAmpSlice is based on two envelope followers on a highpassed version of the signal: one slow that gives the trend, and one fast. Each have features that will interact. The example code below is unfolding the various possibilites in order of complexity.
+   FluidAmpSlice is based on two envelope followers on a high-passed version of the signal: one slow that gives the trend, and one fast. Each has features that will interact. The example code below is unfolding the various possibilities in order of complexity.
 
    The process will return an audio stream with single sample impulses at estimated starting points of the different slices.
 

--- a/doc/AudioTransport.rst
+++ b/doc/AudioTransport.rst
@@ -8,7 +8,7 @@
 
 :discussion:
    Interpolates between the spectra of two sounds using the optimal transport algorithm. This enables morphing and hybridisation of the perceptual qualities of each source linearly.
-   See Henderson and Solomonm (2019) AUDIO TRANSPORT: A GENERALIZED PORTAMENTO VIA OPTIMAL TRANSPORT, DaFx
+   See Henderson and Solomon (2019) AUDIO TRANSPORT: A GENERALIZED PORTAMENTO VIA OPTIMAL TRANSPORT, DaFx
 
    https://arxiv.org/abs/1906.06763
 

--- a/doc/BufAmpFeature.rst
+++ b/doc/BufAmpFeature.rst
@@ -28,7 +28,7 @@
 
 :control numChans:
 
-   For multichannel sources, how many channel should be summed.
+   For multichannel sources, how many channels should be summed.
 
 :control features:
 

--- a/doc/BufAmpGate.rst
+++ b/doc/BufAmpGate.rst
@@ -1,4 +1,4 @@
-:digest: Gate Detection on a Bfufer
+:digest: Gate Detection on a Buffer
 :species: buffer-proc
 :sc-categories: Libraries>FluidDecomposition
 :sc-related: Guides/FluidCorpusManipulation

--- a/doc/BufAmpGate.rst
+++ b/doc/BufAmpGate.rst
@@ -79,7 +79,7 @@
   
 :control highPassFreq:
 
-  The frequency of the fourth-order Linkwitz-Riley high-pass filter (https://en.wikipedia.org/wiki/Linkwitz%E2%80%93Riley_filter) applied to the signal signal to minimise low frequency intermodulation with very short ramp lengths. A frequency of 0 bypasses the filter.
+  The frequency of the fourth-order Linkwitz-Riley high-pass filter (https://en.wikipedia.org/wiki/Linkwitz%E2%80%93Riley_filter) applied to the signal to minimise low frequency intermodulation with very short ramp lengths. A frequency of 0 bypasses the filter.
 
 :control maxSize:
 

--- a/doc/BufAmpSlice.rst
+++ b/doc/BufAmpSlice.rst
@@ -30,7 +30,7 @@
 
 :control numChans:
 
-   For multichannel sources, how many channel should be summed.
+   For multichannel sources, how many channels should be summed.
 
 :control indices:
 
@@ -58,7 +58,7 @@
 
 :control offThreshold:
 
-   The threshold in dB of the relative envelope follower to reset, aka to allow the differential envelop to trigger again.
+   The threshold in dB of the relative envelope follower to reset, aka to allow the differential envelope to trigger again.
 
 :control floor:
 

--- a/doc/BufAmpSlice.rst
+++ b/doc/BufAmpSlice.rst
@@ -5,7 +5,7 @@
 :see-also: AmpSlice, BufAmpGate, BufOnsetSlice, BufNoveltySlice, BufTransientSlice
 :description: Implements an amplitude-based slicer, with various customisable options and conditions to detect relative amplitude changes as onsets.
 :discussion: 
-   FluidBufAmpSlice is based on two envelope followers on a highpassed version of the signal: one slow that gives the trend, and one fast. Each have features that will interact. The example code below is unfolding the various possibilites in order of complexity.
+   FluidBufAmpSlice is based on two envelope followers on a high-passed version of the signal: one slow that gives the trend, and one fast. Each has features that will interact. The example code below is unfolding the various possibilities in order of complexity.
 
    The process will return a buffer which contains indices (in sample) of estimated starting points of different slices.
 

--- a/doc/BufAudioTransport.rst
+++ b/doc/BufAudioTransport.rst
@@ -9,7 +9,7 @@
 :discussion:
    Interpolates between the spectra of two sounds using the optimal transport algorithm. This enables morphing and hybridisation of the perceptual qualities of each source linearly.
 
-   See Henderson and Solomonm (2019) AUDIO TRANSPORT: A GENERALIZED PORTAMENTO VIA OPTIMAL TRANSPORT, DaFx
+   See Henderson and Solomon (2019) AUDIO TRANSPORT: A GENERALIZED PORTAMENTO VIA OPTIMAL TRANSPORT, DaFx
 
    https://arxiv.org/abs/1906.06763
 

--- a/doc/BufChroma.rst
+++ b/doc/BufChroma.rst
@@ -31,7 +31,7 @@
 
 :control numChans:
 
-   For multichannel srcBuf, how many channel should be processed.
+   For multichannel srcBuf, how many channels should be processed.
 
 :control features:
 

--- a/doc/BufChroma.rst
+++ b/doc/BufChroma.rst
@@ -15,7 +15,7 @@
 
 :control source:
 
-   The index of the buffer to use as the source material to be analysed. The different channels of multichannel buffers will be processing sequentially.
+   The index of the buffer to use as the source material to be analysed. The different channels of multichannel buffers will be processed sequentially.
 
 :control startFrame:
 

--- a/doc/BufCompose.rst
+++ b/doc/BufCompose.rst
@@ -7,7 +7,7 @@
    A utility for manipulating the contents of buffers.
 
 :discussion: 
-   This object is the swiss army knife for manipulating buffers and their contents. By specifing ranges of samples and channels to copy, as well as destination and source gains it can provide a powerful interface for performing actions such as a Left/Right to Mid/Side conversion and mixing down multichannel audio
+   This object is the swiss army knife for manipulating buffers and their contents. By specifying ranges of samples and channels to copy, as well as destination and source gains it can provide a powerful interface for performing actions such as a Left/Right to Mid/Side conversion and mixing down multichannel audio
 
 :process: This method triggers the compositing.
 
@@ -24,7 +24,7 @@
 
 :control numFrames:
 
-   The duration (in samples) to copy from the source buffer. The default (-1) copies the full lenght of the buffer.
+   The duration (in samples) to copy from the source buffer. The default (-1) copies the full length of the buffer.
 
 :control startChan:
 
@@ -32,7 +32,7 @@
 
 :control numChans:
 
-   The number of channels from which to copy in the source buffer. This parameter will wrap around the number of channels in the source buffer. The default (-1) copies all of the buffer's channel.
+   The number of channels from which to copy in the source buffer. This parameter will wrap around the number of channels in the source buffer. The default (-1) copies all of the buffer's channels.
 
 :control gain:
 
@@ -48,7 +48,7 @@
 
 :control destStartChan:
 
-   The channel offest in the destination buffer to start writing the source at. The destination buffer will be resized if the number of channels to copy is overflowing.
+   The channel offset in the destination buffer to start writing the source at. The destination buffer will be resized if the number of channels to copy is overflowing.
 
 :control destGain:
 

--- a/doc/BufFlatten.rst
+++ b/doc/BufFlatten.rst
@@ -42,7 +42,7 @@
 
 :control startChan:
 
-   For multichannel ``source`` buffers, which which channel to begin the processing. The default is 0.
+   For multichannel ``source`` buffers, which channel to begin the processing. The default is 0.
 
 :control numChans:
 

--- a/doc/BufHPSS.rst
+++ b/doc/BufHPSS.rst
@@ -9,7 +9,7 @@
     HPSS takes in audio and divides it into two or three outputs, depending on the ``maskingMode``
       * an harmonic component
       * a percussive component
-      * a residual of the previous two if ``maskingMode`` is set to 2 (inter-dependant thresholds). See below.
+      * a residual of the previous two if ``maskingMode`` is set to 2 (interdependant thresholds). See below.
 
     HPSS works by using median filters on the magnitudes of a spectrogram. It makes certain assumptions about what it is looking for in a sound: that in a spectrogram “percussive” elements tend to form vertical “ridges” (tall in frequency band, narrow in time), while stable “harmonic” elements tend to form horizontal “ridges” (narrow in frequency band, long in time). By using median filters across time and frequency respectively, we get initial estimates of the "harmonic-ness" and "percussive-ness" for every spectral bin of every spectral frame in the spectrogram. These are then combined into 'masks' that are applied to the original spectrogram in order to produce a harmonic and percussive output (and residual if ``maskingMode`` = 2).
 

--- a/doc/BufHPSS.rst
+++ b/doc/BufHPSS.rst
@@ -9,13 +9,13 @@
     HPSS takes in audio and divides it into two or three outputs, depending on the ``maskingMode``
       * an harmonic component
       * a percussive component
-      * a residual of the previous two if ``maskingMode`` is set to 2 (interdependant thresholds). See below.
+      * a residual of the previous two if ``maskingMode`` is set to 2 (interdependent thresholds). See below.
 
     HPSS works by using median filters on the magnitudes of a spectrogram. It makes certain assumptions about what it is looking for in a sound: that in a spectrogram “percussive” elements tend to form vertical “ridges” (tall in frequency band, narrow in time), while stable “harmonic” elements tend to form horizontal “ridges” (narrow in frequency band, long in time). By using median filters across time and frequency respectively, we get initial estimates of the "harmonic-ness" and "percussive-ness" for every spectral bin of every spectral frame in the spectrogram. These are then combined into 'masks' that are applied to the original spectrogram in order to produce a harmonic and percussive output (and residual if ``maskingMode`` = 2).
 
     The maskingMode parameter provides different approaches to combining estimates and producing masks. Some settings (especially in modes 1 & 2) will provide better separation but with more artefacts.
 
-    Driedger (2014) suggests that the size of the median filters don't affect the outcome as much as the ``fftSize``. with large FFT sizes, short percussive sounds have less representation, therefore the harmonic component is more strongly represented. The result is that many of the percussive sounds leak into the harmonic component. Small FFT sizes have less resolution in the frequency domain and often lead to a blurring of horizontal structures, therefore harmonic sounds tend to leak into the percussive component. As with all FFT based-processes, finding an FFT size that balances spectral and temporal resolution for a given source sound will benefit the use of this object.
+    Driedger (2014) suggests that the size of the median filters don't affect the outcome as much as the ``fftSize``. With large FFT sizes, short percussive sounds have less representation, therefore the harmonic component is more strongly represented. The result is that many of the percussive sounds leak into the harmonic component. Small FFT sizes have less resolution in the frequency domain and often lead to a blurring of horizontal structures, therefore harmonic sounds tend to leak into the percussive component. As with all FFT based-processes, finding an FFT size that balances spectral and temporal resolution for a given source sound will benefit the use of this object.
 
     For more details visit https://learn.flucoma.org/reference/hpss
 
@@ -74,7 +74,7 @@
    :enum:
 
      :0:
-        Soft masks provide the fewest artefacts, but the weakest separation. Complimentary, soft masks are made for the harmonic and percussive parts by allocating some fraction of every magnitude in the spectrogram to each mask. The two resulting buffers will sum to exactly the original material. This mode uses soft mask in Fitzgerald's (2010) original method of 'Wiener-inspired' filtering. 
+        Soft masks provide the fewest artefacts, but the weakest separation. Complimentary, soft masks are made for the harmonic and percussive parts by allocating some fraction of every magnitude in the spectrogram to each mask. The two resulting buffers will sum to exactly the original material. This mode uses a soft mask in Fitzgerald's (2010) original method of 'Wiener-inspired' filtering. 
 
      :1:
         Binary masks provide better separation, but with more artefacts. The harmonic mask is constructed using a binary decision, based on whether a threshold is exceeded for every magnitude in the spectrogram (these are set using ``harmThreshFreq1``, ``harmThreshAmp1``, ``harmThreshFreq2``, ``harmThreshAmp2``, see below). The percussive mask is then formed as the inverse of the harmonic one, meaning that as above, the two components will sum to the original sound.

--- a/doc/BufHPSS.rst
+++ b/doc/BufHPSS.rst
@@ -80,7 +80,7 @@
         Binary masks provide better separation, but with more artefacts. The harmonic mask is constructed using a binary decision, based on whether a threshold is exceeded for every magnitude in the spectrogram (these are set using ``harmThreshFreq1``, ``harmThreshAmp1``, ``harmThreshFreq2``, ``harmThreshAmp2``, see below). The percussive mask is then formed as the inverse of the harmonic one, meaning that as above, the two components will sum to the original sound.
 
      :2:
-        Soft masks (with a third stream containing a residual component). First, binary masks are made separately for the harmonic and percussive components using different thresholds (set with the respective ``harmThresh-`` and ``percThresh-`` parameters below). Because these masks aren't guaranteed to represent the entire spectrogram, any residual energy is considered as a third output.  The independently created binary masks are converted to soft masks at the end of the process so that everything null sums. 
+        Soft masks (with a third stream containing a residual component). First, binary masks are made separately for the harmonic and percussive components using different thresholds (set with the respective ``harmThresh-`` and ``percThresh-`` parameters below). Because these masks aren't guaranteed to represent the entire spectrogram, any residual energy is considered as a third output.  The independently created binary masks are converted to soft masks at the end of the process so that everything null-sums. 
 
 :control harmThresh:
 

--- a/doc/BufLoudness.rst
+++ b/doc/BufLoudness.rst
@@ -33,7 +33,7 @@
 
 :control numChans:
 
-   For multichannel srcBuf, how many channel should be processed.
+   For multichannel srcBuf, how many channels should be processed.
 
 :control features:
 

--- a/doc/BufLoudness.rst
+++ b/doc/BufLoudness.rst
@@ -17,7 +17,7 @@
 
 :control source:
 
-   The index of the buffer to use as the source material to be described. The different channels of multichannel buffers will be processing sequentially.
+   The index of the buffer to use as the source material to be described. The different channels of multichannel buffers will be processed sequentially.
 
 :control startFrame:
 

--- a/doc/BufMFCC.rst
+++ b/doc/BufMFCC.rst
@@ -6,11 +6,11 @@
 :description: A classic timbral spectral descriptor, the Mel-Frequency Cepstral Coefficients (MFCCs).
 :discussion:
     
-   MFCC stands for Mel-Frequency Cepstral Coefficients ("cepstral" is pronounced like "kepstral"). This analysis is often used for timbral description and timbral comparison. It compresses the overall spectrum into a smaller number of coefficients that, when taken together, describe the general contour the spectrum.
+   MFCC stands for Mel-Frequency Cepstral Coefficients ("cepstral" is pronounced like "kepstral"). This analysis is often used for timbral description and timbral comparison. It compresses the overall spectrum into a smaller number of coefficients that, when taken together, describe the general contour of the spectrum.
 
-   The MFCC values are derived by first computing a mel-frequency spectrum, just as in :fluid-obj:`MelBands`. ``numCoeffs`` coefficients are then calculated by using that mel-frequency spectrum as input to the discrete cosine transform. This means that the shape of the mel-frequency spectrum is compared to a number of cosine wave shapes (different cosines shapes created from different frequencies). Each MFCC value (i.e., "coefficient") represents how similar the mel-frequency spectrum is to one of these cosine shapes. 
+   The MFCC values are derived by first computing a mel-frequency spectrum, just as in :fluid-obj:`MelBands`. ``numCoeffs`` coefficients are then calculated by using that mel-frequency spectrum as input to the discrete cosine transform. This means that the shape of the mel-frequency spectrum is compared to a number of cosine wave shapes (different cosine shapes created from different frequencies). Each MFCC value (i.e., "coefficient") represents how similar the mel-frequency spectrum is to one of these cosine shapes. 
 
-   Other that the 0th coefficient, MFCCs are unchanged by differences in the overall energy of the spectrum (which relates to how we perceive loudness). This means that timbres with similar spectral contours, but different volumes, will still have similar MFCC values, other than MFCC 0. To remove any indication of loudness but keep the information about timbre, we can ignore MFCC 0 by setting the parameter ``startCoeff`` to 1.
+   Other than the 0th coefficient, MFCCs are unchanged by differences in the overall energy of the spectrum (which relates to how we perceive loudness). This means that timbres with similar spectral contours, but different volumes, will still have similar MFCC values, other than MFCC 0. To remove any indication of loudness but keep the information about timbre, we can ignore MFCC 0 by setting the parameter ``startCoeff`` to 1.
 
    For more information visit https://learn.flucoma.org/reference/mfcc/.
 
@@ -18,7 +18,7 @@
    
 :control source:
 
-   The index of the buffer to use as the source material to be analysed. The different channels of multichannel buffers will be processing sequentially.
+   The index of the buffer to use as the source material to be analysed. The different channels of multichannel buffers will be processed sequentially.
 
 :control startFrame:
 
@@ -74,4 +74,4 @@
 
 :control padding:
 
-   Controls the zero-padding added to either end of the source buffer or segment. Possible values are 0 (no padding), 1 (default, half the window size), or 2 (window size - hop size). Padding ensures that all input samples are completely analysed: with no padding, the first analysis window starts at time 0, and the samples at either end will be tapered by the STFT windowing function. Mode 1 has the effect of centring the first sample in the analysis window and ensuring that the very start and end of the segment are accounted for in the analysis. Mode 2 can be useful when the overlap factor (window size / hop size) is greater than 2, to ensure that the input samples at either end of the segment are covered by the same number of analysis frames as the rest of the analysed material.
+   Controls the zero-padding added to either end of the source buffer or segment. Possible values are 0 (no padding), 1 (default, half the window size), or 2 (window size - hop size). Padding ensures that all input samples are completely analysed: with no padding, the first analysis window starts at time 0, and the samples at either end will be tapered by the STFT windowing function. Mode 1 has the effect of centering the first sample in the analysis window and ensuring that the very start and end of the segment are accounted for in the analysis. Mode 2 can be useful when the overlap factor (window size / hop size) is greater than 2, to ensure that the input samples at either end of the segment are covered by the same number of analysis frames as the rest of the analysed material.

--- a/doc/BufMFCC.rst
+++ b/doc/BufMFCC.rst
@@ -6,9 +6,9 @@
 :description: A classic timbral spectral descriptor, the Mel-Frequency Cepstral Coefficients (MFCCs).
 :discussion:
     
-   MFCC stands for Mel-Frequency Cepstral Coefficients ("cepstral" is pronounced like "kepstral"). This analysis is often used for timbral description and timbral comparison. It compresses the overall spectrum into a smaller number of coefficients that, when taken together, describe the general contour the the spectrum.
+   MFCC stands for Mel-Frequency Cepstral Coefficients ("cepstral" is pronounced like "kepstral"). This analysis is often used for timbral description and timbral comparison. It compresses the overall spectrum into a smaller number of coefficients that, when taken together, describe the general contour the spectrum.
 
-   The MFCC values are derived by first computing a mel-frequency spectrum, just as in :fluid-obj:`MelBands`. ``numCoeffs`` coefficients are then calculated by using that mel-frequency spectrum as input to the discrete cosine transform. This means that the shape of the mel-frequency spectrum is compared to a number of cosine wave shapes (different cosines shapes created from different different frequencies). Each MFCC value (i.e., "coefficient") represents how similar the mel-frequency spectrum is to one of these cosine shapes. 
+   The MFCC values are derived by first computing a mel-frequency spectrum, just as in :fluid-obj:`MelBands`. ``numCoeffs`` coefficients are then calculated by using that mel-frequency spectrum as input to the discrete cosine transform. This means that the shape of the mel-frequency spectrum is compared to a number of cosine wave shapes (different cosines shapes created from different frequencies). Each MFCC value (i.e., "coefficient") represents how similar the mel-frequency spectrum is to one of these cosine shapes. 
 
    Other that the 0th coefficient, MFCCs are unchanged by differences in the overall energy of the spectrum (which relates to how we perceive loudness). This means that timbres with similar spectral contours, but different volumes, will still have similar MFCC values, other than MFCC 0. To remove any indication of loudness but keep the information about timbre, we can ignore MFCC 0 by setting the parameter ``startCoeff`` to 1.
 

--- a/doc/BufMelBands.rst
+++ b/doc/BufMelBands.rst
@@ -6,9 +6,9 @@
 :description: Magnitudes for a number of perceptually-evenly spaced bands.
 :discussion: 
 
-  :fluid-obj:`BufMelBands` returns a Mel-Frequency Spectrum comprised of the user-defined ``numBands``. The Mel-Frequency Spectrum is a histogram of FFT bins bundled according their relationship to the Mel scale ( https://en.wikipedia.org/wiki/Mel_scale ) which represents frequency space logarithmically, mimicking how humans perceive pitch distance. The name "Mel" derives from the word "melody". The Hz-to-Mel conversion used by :fluid-obj:`BufMelBands` is ``mel = 1127.01048 * log(hz / 700.0 + 1.0)``. 
+  :fluid-obj:`BufMelBands` returns a Mel-Frequency Spectrum containing the user-defined ``numBands``. The Mel-Frequency Spectrum is a histogram of FFT bins bundled according to their relationship to the Mel scale ( https://en.wikipedia.org/wiki/Mel_scale ) which represents frequency space logarithmically, mimicking how humans perceive pitch distance. The name "Mel" derives from the word "melody". The Hz-to-Mel conversion used by :fluid-obj:`BufMelBands` is ``mel = 1127.01048 * log(hz / 700.0 + 1.0)``. 
   
-  This implementation allows to select the range and number of bands dynamically. The ``numBands`` MelBands will be perceptually equally distributed between ``minFreq`` and ``maxFreq``.
+  This implementation allows selection of the range and number of bands dynamically. The ``numBands`` MelBands will be perceptually equally distributed between ``minFreq`` and ``maxFreq``.
 
   When using a high value for ``numBands``, you may end up with empty channels (filled with zeros) in the MelBands output. This is because there is not enough information in the FFT analysis to properly calculate values for every MelBand. Increasing the ``fftSize`` will ensure you have values for all the MelBands.
   
@@ -20,7 +20,7 @@
 
 :control source:
 
-   The index of the buffer to use as the source material to be analysed. The different channels of multichannel buffers will be processing sequentially.
+   The index of the buffer to use as the source material to be analysed. The different channels of multichannel buffers will be processed sequentially.
 
 :control startFrame:
 
@@ -76,7 +76,7 @@
 
 :control padding:
 
-   Controls the zero-padding added to either end of the source buffer or segment. Possible values are 0 (no padding), 1 (default, half the window size), or 2 (window size - hop size). Padding ensures that all input samples are completely analysed: with no padding, the first analysis window starts at time 0, and the samples at either end will be tapered by the STFT windowing function. Mode 1 has the effect of centring the first sample in the analysis window and ensuring that the very start and end of the segment are accounted for in the analysis. Mode 2 can be useful when the overlap factor (window size / hop size) is greater than 2, to ensure that the input samples at either end of the segment are covered by the same number of analysis frames as the rest of the analysed material.
+   Controls the zero-padding added to either end of the source buffer or segment. Possible values are 0 (no padding), 1 (default, half the window size), or 2 (window size - hop size). Padding ensures that all input samples are completely analysed: with no padding, the first analysis window starts at time 0, and the samples at either end will be tapered by the STFT windowing function. Mode 1 has the effect of centering the first sample in the analysis window and ensuring that the very start and end of the segment are accounted for in the analysis. Mode 2 can be useful when the overlap factor (window size / hop size) is greater than 2, to ensure that the input samples at either end of the segment are covered by the same number of analysis frames as the rest of the analysed material.
 
 :control action:
 

--- a/doc/BufNMF.rst
+++ b/doc/BufNMF.rst
@@ -48,7 +48,7 @@
 
 :control numChans:
 
-   For multichannel srcBuf, how many channel should be processed.
+   For multichannel srcBuf, how many channels should be processed.
 
 :control resynth:
 

--- a/doc/BufNMF.rst
+++ b/doc/BufNMF.rst
@@ -7,14 +7,14 @@
 :discussion: 
    NMF has been a popular technique in signal processing research for things like source separation and transcription (see Smaragdis and Brown, Non-Negative Matrix Factorization for Polyphonic Music Transcription.), although its creative potential is so far relatively  unexplored.
 
-   The algorithm takes a buffer in and divides it into a number of components, determined by the components argument. It works iteratively, by trying to find a combination of spectral templates ('bases') and envelopes ('activations') that yield the original magnitude spectrogram when added together. By and large, there is no unique answer to this question (i.e. there are different ways of accounting for an evolving spectrum in terms of some set of templates and envelopes). In its basic form, NMF is a form of unsupervised learning: it starts with some random data and then converges towards something that minimizes the distance between its generated data and the original:it tends to converge very quickly at first and then level out. Fewer iterations mean less processing, but also less predictable results.
+   The algorithm takes a buffer in and divides it into a number of components, determined by the components argument. It works iteratively, by trying to find a combination of spectral templates ('bases') and envelopes ('activations') that yield the original magnitude spectrogram when added together. By and large, there is no unique answer to this question (i.e. there are different ways of accounting for an evolving spectrum in terms of some set of templates and envelopes). In its basic form, NMF is a form of unsupervised learning: it starts with some random data and then converges towards something that minimises the distance between its generated data and the original:it tends to converge very quickly at first and then level out. Fewer iterations mean less processing, but also less predictable results.
 
    The object can return either or all of the following:
    	* a spectral contour of each component in the form of a magnitude spectrogram (called a basis in NMF lingo);
    	* an amplitude envelope of each component in the form of gains for each consecutive frame of the underlying spectrogram (called an activation in NMF lingo);
-   	* an audio reconstruction of each components in the time domain.
+   	* an audio reconstruction of each component in the time domain.
 
-   The bases and activations can be used to make a kind of vocoder based on what NMF has 'learned' from the original data. Alternatively, taking the matrix product of a basis and an activation will yield a synthetic magnitude spectrogram of a component (which could be reconsructed, given some phase informaiton from somewhere).
+   The bases and activations can be used to make a kind of vocoder based on what NMF has 'learned' from the original data. Alternatively, taking the matrix product of a basis and an activation will yield a synthetic magnitude spectrogram of a component (which could be reconstructed, given some phase information from somewhere).
 
    Some additional options and flexibility can be found through combinations of the basesMode and actMode arguments. If these flags are set to 1, the object expects to be supplied with pre-formed spectra (or envelopes) that will be used as seeds for the decomposition, providing more guided results. When set to 2, the supplied buffers won't be updated, so become templates to match against instead. Note that having both bases and activations set to 2 doesn't make sense, so the object will complain.
 
@@ -32,7 +32,7 @@
 
 :control source:
 
-   The index of the buffer to use as the source material to be decomposed through the NMF process. The different channels of multichannel buffers will be processing sequentially.
+   The index of the buffer to use as the source material to be decomposed through the NMF process. The different channels of multichannel buffers will be processed sequentially.
 
 :control startFrame:
 
@@ -52,7 +52,7 @@
 
 :control resynth:
 
-   The index of the buffer where the different reconstructed components will be reconstructed. The buffer will be resized to ``components * numChannelsProcessed`` channels and ``sourceDuration`` lenght. If ``nil`` is provided, the reconstruction will not happen.
+   The index of the buffer where the different reconstructed components will be reconstructed. The buffer will be resized to ``components * numChannelsProcessed`` channels and ``sourceDuration`` length. If ``nil`` is provided, the reconstruction will not happen.
 
 :control resynthMode:
 
@@ -64,12 +64,12 @@
 
 :control basesMode:
 
-   This flag decides of how the basis buffer passed as the previous argument is treated.
+   This flag decides how the basis buffer passed as the previous argument is treated.
 
    :enum:
 
       :0:
-         The bases are seeded randomly, and the resulting ones will be written after the process in the passed buffer. The buffer is resized to ``components * numChannelsProcessed`` channels and ``(fftSize / 2 + 1)`` lenght.
+         The bases are seeded randomly, and the resulting ones will be written after the process in the passed buffer. The buffer is resized to ``components * numChannelsProcessed`` channels and ``(fftSize / 2 + 1)`` length.
 
       :1:
          The passed buffer is considered as seed for the bases. Its dimensions should match the values above. The resulting bases will replace the seed ones.
@@ -83,12 +83,12 @@
 
 :control actMode:
 
-   This flag decides of how the activation buffer passed as the previous argument is treated.
+   This flag decides how the activation buffer passed as the previous argument is treated.
 
    :enum:
 
       :0:
-         The activations are seeded randomly, and the resulting ones will be written after the process in the passed buffer. The buffer is resized to ``components * numChannelsProcessed`` channels and ``(sourceDuration / hopsize + 1)`` lenght.
+         The activations are seeded randomly, and the resulting ones will be written after the process in the passed buffer. The buffer is resized to ``components * numChannelsProcessed`` channels and ``(sourceDuration / hopsize + 1)`` length.
 
       :1:
          The passed buffer is considered as seed for the activations. Its dimensions should match the values above. The resulting activations will replace the seed ones.

--- a/doc/BufNMFCross.rst
+++ b/doc/BufNMFCross.rst
@@ -34,7 +34,7 @@
 
 :control continuity:
 
-   Promote the use of N successive source frames, giving greater continuity in the result. This can not be bigger than the sizes of the ``source`` buffer, but useful values tend to be much lower (in the tens). The default is 7.
+   Promote the use of N successive source frames, giving greater continuity in the result. This can not be bigger than the size of the ``source`` buffer, but useful values tend to be much lower (in the tens). The default is 7.
 
 :control iterations:
 
@@ -50,4 +50,4 @@
 
 :control fftSize:
 
-   The analsyis FFT size in samples The default of -1 indicates ``fftSize`` = ``windowSize``
+   The analysis FFT size in samples The default of -1 indicates ``fftSize`` = ``windowSize``

--- a/doc/BufNMFSeed.rst
+++ b/doc/BufNMFSeed.rst
@@ -16,11 +16,11 @@
 
 :control bases:
 
-   The |buffer| where the bases will be written to. These are suggested seed for a BufNMF process. The number of bases (i.e., channels) in this buffer when the process is complete is the number of components needed to cover the requested percentage of variance in the buffer.
+   The |buffer| where the bases will be written to. These bases are suggested seeds for a BufNMF process. The number of bases (i.e., channels) in this buffer when the process is complete is the number of components needed to cover the requested percentage of variance in the buffer.
 
 :control activations:
 
-   The |buffer| where the activations will be written to. These are suggested seed for a BufNMF process. The number of bases (i.e., channels) in this buffer when the process is complete is the number of components needed to cover the requested percentage of variance in the buffer.
+   The |buffer| where the activations will be written to. These bases are suggested seeds for a BufNMF process. The number of bases (i.e., channels) in this buffer when the process is complete is the number of components needed to cover the requested percentage of variance in the buffer.
 
 :control minComponents:
 

--- a/doc/BufNoveltyFeature.rst
+++ b/doc/BufNoveltyFeature.rst
@@ -32,7 +32,7 @@
 
 :control numChans:
 
-   For multichannel srcBuf, how many channel should be summed.
+   For multichannel srcBuf, how many channels should be summed.
 
 :control features:
 
@@ -65,7 +65,7 @@
 
 :control filterSize:
 
-   The size of a smoothing filter that is applied on the novelty curve. A larger filter filter size allows for cleaner cuts on very sharp changes.
+   The size of a smoothing filter that is applied on the novelty curve. A larger filter size allows for cleaner cuts on very sharp changes.
 
 :control windowSize:
 

--- a/doc/BufNoveltySlice.rst
+++ b/doc/BufNoveltySlice.rst
@@ -31,7 +31,7 @@
 
 :control numChans:
 
-   For multichannel srcBuf, how many channel should be summed.
+   For multichannel srcBuf, how many channels should be summed.
 
 :control indices:
 
@@ -68,7 +68,7 @@
 
 :control filterSize:
 
-   The size of a smoothing filter that is applied on the novelty curve. A larger filter filter size allows for cleaner cuts on very sharp changes.
+   The size of a smoothing filter that is applied on the novelty curve. A larger filter size allows for cleaner cuts on very sharp changes.
 
 :control minSliceLength:
 

--- a/doc/BufNoveltySlice.rst
+++ b/doc/BufNoveltySlice.rst
@@ -3,9 +3,9 @@
 :sc-categories: Libraries>FluidDecomposition, UGens>Buffer
 :sc-related: Guides/FluidCorpusManipulation
 :see-also: NoveltySlice, BufAmpSlice, BufOnsetSlice, BufTransientSlice
-:description: A non-real-time slicer using an algorithm assessing novelty in the signal to estimate the slicing points.
+:description: A non-realtime slicer using an algorithm assessing novelty in the signal to estimate the slicing points.
 :discussion: 
-   A novelty curve is derived from running a kernel across the diagonal of the similarity matrix, and looking for peak of changes. It implements the seminal results published in  'Automatic Audio Segmentation Using a Measure of Audio Novelty' by J Foote.
+   A novelty curve is derived from running a kernel across the diagonal of the similarity matrix, and looking for peaks of changes. It implements the seminal results published in  'Automatic Audio Segmentation Using a Measure of Audio Novelty' by J Foote.
 
    The process will return a buffer which contains indices (in sample) of estimated starting points of different slices.
 
@@ -64,7 +64,7 @@
 
 :control threshold:
 
-   The normalised threshold, between 0 an 1, on the novelty curve to consider it a segmentation point.
+   The normalised threshold, between 0 and 1, on the novelty curve to consider it a segmentation point.
 
 :control filterSize:
 

--- a/doc/BufOnsetFeature.rst
+++ b/doc/BufOnsetFeature.rst
@@ -49,7 +49,7 @@
          **HFC** thresholds on (sum of (squared magnitudes * binNum) / nBins)
 
       :2:
-         **SpectralFlux** thresholds on (diffence in magnitude between consecutive frames, half rectified)
+         **SpectralFlux** thresholds on (difference in magnitude between consecutive frames, half rectified)
 
       :3:
          **MKL** thresholds on (sum of log of magnitude ratio per bin) (or equivalently, sum of difference of the log magnitude per bin) (like Onsets mkl)

--- a/doc/BufOnsetFeature.rst
+++ b/doc/BufOnsetFeature.rst
@@ -30,7 +30,7 @@
 
 :control numChans:
 
-   For multichannel sources, how many channel should be summed.
+   For multichannel sources, how many channels should be summed.
 
 :control features:
 
@@ -74,7 +74,7 @@
 
 :control filterSize:
 
-   The size of a smoothing filter that is applied on the novelty curve. A larger filter filter size allows for cleaner cuts on very sharp changes.
+   The size of a smoothing filter that is applied on the novelty curve. A larger filter size allows for cleaner cuts on very sharp changes.
 
 :control frameDelta:
 

--- a/doc/BufOnsetSlice.rst
+++ b/doc/BufOnsetSlice.rst
@@ -30,7 +30,7 @@
 
 :control numChans:
 
-   For multichannel sources, how many channel should be summed.
+   For multichannel sources, how many channels should be summed.
 
 :control indices:
 
@@ -82,7 +82,7 @@
 
 :control filterSize:
 
-   The size of a smoothing filter that is applied on the novelty curve. A larger filter filter size allows for cleaner cuts on very sharp changes.
+   The size of a smoothing filter that is applied on the novelty curve. A larger filter size allows for cleaner cuts on very sharp changes.
 
 :control frameDelta:
 

--- a/doc/BufOnsetSlice.rst
+++ b/doc/BufOnsetSlice.rst
@@ -49,7 +49,7 @@
          **HFC** thresholds on (sum of (squared magnitudes * binNum) / nBins)
 
       :2:
-         **SpectralFlux** thresholds on (diffence in magnitude between consecutive frames, half rectified)
+         **SpectralFlux** thresholds on (difference in magnitude between consecutive frames, half rectified)
 
       :3:
          **MKL** thresholds on (sum of log of magnitude ratio per bin) (or equivalently, sum of difference of the log magnitude per bin) (like Onsets mkl)
@@ -86,7 +86,7 @@
 
 :control frameDelta:
 
-   For certain metrics (HFC, SpectralFlux, MKL, Cosine), the distance does not have to be computed between consecutive frames. By default (0) it is, otherwise this sets the distane between the comparison window in samples.
+   For certain metrics (HFC, SpectralFlux, MKL, Cosine), the distance does not have to be computed between consecutive frames. By default (0) it is, otherwise this sets the distance between the comparison window in samples.
 
 :control windowSize:
 

--- a/doc/BufPitch.rst
+++ b/doc/BufPitch.rst
@@ -42,7 +42,7 @@
 
 :control numChans:
 
-   For multichannel ``source``, how many channel should be processed. The default of -1 indicates to analyse through the last channel in the buffer.
+   For multichannel ``source``, how many channels should be processed. The default of -1 indicates to analyse through the last channel in the buffer.
 
 :control features:
 

--- a/doc/BufPitch.rst
+++ b/doc/BufPitch.rst
@@ -22,7 +22,7 @@
 
 :control source:
 
-   The index of the buffer to use as the source material to be pitch-tracked. The different channels of multichannel buffers will be processing sequentially.
+   The index of the buffer to use as the source material to be pitch-tracked. The different channels of multichannel buffers will be processed sequentially.
 
 :control select:
 
@@ -65,11 +65,11 @@
 
 :control minFreq:
 
-   The minimum frequency that the algorithm will search for an estimated fundamental. This sets the lowest value that will be generated. The default is 20.
+   The minimum fundamental frequency that the algorithm withh search for. This sets the lowest value that will be generated. The default is 20.
 
 :control maxFreq:
 
-   The maximum frequency that the algorithm will search for an estimated fundamental. This sets the highest value that will be generated. The default is 10000.
+   The maximum fundamental frequency that the algorithm withh search for. This sets the highest value that will be generated. The default is 10000.
 
 :control unit:
 

--- a/doc/BufSines.rst
+++ b/doc/BufSines.rst
@@ -20,7 +20,7 @@
 
 :control source:
 
-   The index of the buffer to use as the source material to be decomposed through the sinusoidal modelling process. The different channels of multichannel buffers will be processing sequentially.
+   The index of the buffer to use as the source material to be decomposed through the sinusoidal modelling process. The different channels of multichannel buffers will be processed sequentially.
 
 :control startFrame:
 

--- a/doc/BufSines.rst
+++ b/doc/BufSines.rst
@@ -36,7 +36,7 @@
 
 :control numChans:
 
-   For multichannel srcBuf, how many channel should be processed.
+   For multichannel srcBuf, how many channels should be processed.
 
 :control sines:
 

--- a/doc/BufSpectralShape.rst
+++ b/doc/BufSpectralShape.rst
@@ -28,7 +28,7 @@
 
 :control source:
 
-   The index of the buffer to use as the source material to be described through the various descriptors. The different channels of multichannel buffers will be processing sequentially.
+   The index of the buffer to use as the source material to be described through the various descriptors. The different channels of multichannel buffers will be processed sequentially.
 
 :control startFrame:
 

--- a/doc/BufSpectralShape.rst
+++ b/doc/BufSpectralShape.rst
@@ -10,7 +10,7 @@
    * the four first statistical moments (https://en.wikipedia.org/wiki/Moment_(mathematics) ):
   
      * the spectral centroid (1) in Hertz. This is the point that splits the spectrum in 2 halves of equal energy. It is the weighted average of the magnitude spectrum.
-     * the spectral spread (2) in Hertz. This is the standard deviation of the spectrum envelop, or the average of the distance to the centroid.
+     * the spectral spread (2) in Hertz. This is the standard deviation of the spectrum envelope, or the average of the distance to the centroid.
      * the normalised skewness (3) as ratio. This indicates how tilted is the spectral curve in relation to the middle of the spectral frame, i.e. half of the Nyquist frequency. If it is below the frequency of the magnitude spectrum, it is positive.
      * the normalised kurtosis (4) as ratio. This indicates how focused is the spectral curve. If it is peaky, it is high.
   
@@ -44,7 +44,7 @@
 
 :control numChans:
 
-   For multichannel srcBuf, how many channel should be processed.
+   For multichannel srcBuf, how many channels should be processed.
 
 :control features:
 

--- a/doc/BufStats.rst
+++ b/doc/BufStats.rst
@@ -50,7 +50,7 @@
 
 :control numDerivs:
 
-   The number of derivatives of the original time-series to compute statistics on. The default of 0 will compute statistics on no derivates, only the original time-series itself. Setting this parameter > 0 (maximum of 2) will return the same seven statistics computed on consecutive derivatives of the channel's time-series. (``numDerivs`` = 1 will return the channel's statistics and the statistics of the first derivative, ``numDerivs`` = 2 will return the channel's statistics and the statistics of the first and second derivatives.) The derivative statistics are useful to describe the rate of change of the time series.
+   The number of derivatives of the original time-series to compute statistics on. The default of 0 will compute statistics on no derivatives, only the original time-series itself. Setting this parameter > 0 (maximum of 2) will return the same seven statistics computed on consecutive derivatives of the channel's time-series. (``numDerivs`` = 1 will return the channel's statistics and the statistics of the first derivative, ``numDerivs`` = 2 will return the channel's statistics and the statistics of the first and second derivatives.) The derivative statistics are useful to describe the rate of change of the time series.
 
 :control low:
 

--- a/doc/BufThreadDemo.rst
+++ b/doc/BufThreadDemo.rst
@@ -4,18 +4,15 @@
 :sc-related: Guides/FluidCorpusManipulation, Guides/FluidBufMultiThreading
 :see-also: 
 :description: 
-   This class implements a simple tutorial object to illustrate and experiment with the behaviour of the FluidBuf* objects. It simply starts a process that will, upon completion of its task, write a single value to the destination buffer. This is the general behaviour of much of the CPU consuming FluidBuf* objects. In this case, as a toy example, the task is simply just wait and do nothing, to simulate a task that would actually take that long in the background.
+   Implements a tutorial object to illustrate and experiment with the behaviour of the FluidBuf* objects. To simulate their behaviour in various blocking modes, the object after waiting for **time** milliseconds, return its delay length as a float writen at index [0] of the specified destination buffer.
 
-   The process will, after waiting for **time** milliseconds, return its delay length as a Float writen at index [0] of the specified destination buffer.
-
-:process: This is the method that calls for the job to be done. In this case, simply waiting **time** milliseconds before writing a value in the destination buffer.
+:process: 
+   This is the method that calls for the job to be done. In this case, simply waiting **time** milliseconds before writing a value in the destination buffer.
 
 
 :control result:
-
    The destination buffer, where the value should be written at the end of the process.
 
 :control time:
-
    The duration in milliseconds of the delay that the background thread will wait for before yielding the value to the destination buffer.
 

--- a/doc/BufTransientSlice.rst
+++ b/doc/BufTransientSlice.rst
@@ -47,7 +47,7 @@
 
 :control blockSize:
 
-  The size of audio chunk (in samples) on which the process is operating. This determines the maximum duration (in samples) of a detected transient, which cannot be more than than half of ``blockSize - order``.
+  The size of audio chunk (in samples) on which the process is operating. This determines the maximum duration (in samples) of a detected transient, which cannot be more than half of ``blockSize - order``.
 
 :control padSize:
 

--- a/doc/BufTransientSlice.rst
+++ b/doc/BufTransientSlice.rst
@@ -47,7 +47,7 @@
 
 :control blockSize:
 
-  The size of audio chunk (in samples) on which the process is operating. This determines the maximum duration (in samples) of a detected transient, which cannot be more than half of ``blockSize - order``.
+  The size of audio block (in samples) on which the process is operating. This determines the maximum duration (in samples) of a detected transient, which cannot be more than half of ``blockSize - order``.
 
 :control padSize:
 
@@ -59,11 +59,11 @@
 
 :control threshFwd:
 
- The threshold applied to the smoothed forward prediction error for determining an onset. The units are roughly in standard deviations, thus can be considered how "deviant", or anomalous, the signal must be to be detected as a transient. It allows tight start of the identification of the anomaly as it proceeds forward.
+ The threshold applied to the smoothed forward prediction error for determining an onset. The units are roughly in standard deviations, thus can be considered how "deviant", or anomalous, the signal must be to be detected as a transient. It allows tight identification of the start of the anomaly as it proceeds forward.
 
 :control threshBack:
 
- The threshold applied to the smoothed backward prediction error for determining an offset. The units are roughly in standard deviations, thus can be considered how "deviant", or anomalous, the signal must be to be considered transient. When the smoothed error function goes below ``threshBack`` an offset is identified. As it proceeds backwards in time, it allows tight ending of the identification of the anomaly.
+ The threshold applied to the smoothed backward prediction error for determining an offset. The units are roughly in standard deviations, thus can be considered how "deviant", or anomalous, the signal must be to be considered transient. When the smoothed error function goes below ``threshBack`` an offset is identified. As it proceeds backwards in time, it allows tight identification of the end of the anomaly.
 
 :control windowSize:
 
@@ -71,7 +71,7 @@
 
 :control clumpLength:
 
- The window size in samples within which anomalous samples will be clumped together to avoid over detecting in time. This is similar to setting a minimum slice length.
+ The window size in samples within which anomalous samples will be clumped together to avoid over-detecting in time. This is similar to setting a minimum slice length.
 
 :control minSliceLength:
 

--- a/doc/BufTransients.rst
+++ b/doc/BufTransients.rst
@@ -21,7 +21,7 @@
 
 :control source:
 
-   The |buffer| to use as the source material to detect transients in. The different channels of multichannel buffers will be processing sequentially.
+   The |buffer| to use as the source material to detect transients in. The different channels of multichannel buffers will be processed sequentially.
 
 :control startFrame:
 
@@ -53,7 +53,7 @@
 
 :control blockSize:
 
-   The size of audio chunk (in samples) on which the process is operating. This determines the maximum duration (in samples) of a detected transient, which cannot be more than half of ``blockSize - order``.
+   The size of the audio block (in samples) on which the process is operating. This determines the maximum duration (in samples) of a detected transient, which cannot be more than half of ``blockSize - order``.
 
 :control padSize:
 
@@ -65,11 +65,11 @@
 
 :control threshFwd:
 
-  The threshold applied to the smoothed forward prediction error for determining an onset. The units are roughly in standard deviations, thus can be considered how "deviant", or anomalous, the signal must be to be detected as a transient. It allows tight start of the identification of the anomaly as it proceeds forward.
+  The threshold applied to the smoothed forward prediction error for determining an onset. The units are roughly in standard deviations, thus can be considered how "deviant", or anomalous, the signal must be to be detected as a transient. It allows tight identification of the start of the anomaly as it proceeds forward.
 
 :control threshBack:
 
-  The threshold applied to the smoothed backward prediction error for determining an offset. The units are roughly in standard deviations, thus can be considered how "deviant", or anomalous, the signal must be to be considered transient. When the smoothed error function goes below ``threshBack`` an offset is identified. As it proceeds backwards in time, it allows tight ending of the identification of the anomaly.
+  The threshold applied to the smoothed backward prediction error for determining an offset. The units are roughly in standard deviations, thus can be considered how "deviant", or anomalous, the signal must be to be considered transient. When the smoothed error function goes below ``threshBack`` an offset is identified. As it proceeds backwards in time, it allows tight identification of the end of the anomaly.
 
 :control windowSize:
 
@@ -77,4 +77,4 @@
 
 :control clumpLength:
 
-  The window size in samples within which anomalous samples will be clumped together to avoid over detecting in time. This is like setting a minimum transient length.
+  The window size in samples within which anomalous samples will be clumped together to avoid over-detecting in time. This is like setting a minimum transient length.

--- a/doc/BufTransients.rst
+++ b/doc/BufTransients.rst
@@ -53,7 +53,7 @@
 
 :control blockSize:
 
-   The size of audio chunk (in samples) on which the process is operating. This determines the maximum duration (in samples) of a detected transient, which cannot be more than than half of ``blockSize - order``.
+   The size of audio chunk (in samples) on which the process is operating. This determines the maximum duration (in samples) of a detected transient, which cannot be more than half of ``blockSize - order``.
 
 :control padSize:
 

--- a/doc/Chroma.rst
+++ b/doc/Chroma.rst
@@ -1,4 +1,4 @@
-:digest: A histogram of pitch classes in Real-Time
+:digest: A histogram of pitch classes in Realtime
 :species: descriptor
 :sc-categories: Libraries>FluidDecomposition
 :sc-related: Guides/FluidCorpusManipulation, Classes/FluidMFCC
@@ -7,7 +7,7 @@
 :discussion: 
    Also known as a chromagram, this typically allows you to get a contour of how much each semitone is represented in the spectrum over time. The number of chroma bins (and, thus, pitch classes) and the central reference frequency can be adjusted.
 
-   The process will return a multichannel control steam of size maxNumChroma, which will be repeated if no change happens within the algorithm, i.e. when the hopSize is larger than the signal vector size.
+   The process will return a multichannel control stream of size maxNumChroma, which will be repeated if no change happens within the algorithm, i.e. when the hopSize is larger than the signal vector size.
 
 :process: The audio rate in, control rate out version of the object.
 :output: A  KR signal of maxNumChroma channels, giving the measure amplitudes for each chroma bin. The latency is windowSize.

--- a/doc/DataSet.rst
+++ b/doc/DataSet.rst
@@ -62,7 +62,7 @@
 
    :arg labelSet: The FluidLabelSet in which to dump the point's IDs associated with their reference frame number (or channel number if transposed).
 
-   Dump the content of the dataset to a |buffer|, with optional transposition, and a map of frames/channel to the original IDs as a FluidLabelSet.
+   Dump the content of the dataset to a |buffer|, with optional transposition, and a map of frames/channels to the original IDs as a FluidLabelSet.
 
 :message fromBuffer:
 
@@ -78,7 +78,7 @@
 
    :arg labelSet: The FluidLabelSet to export to. Its content will be replaced.
 
-   Export to the dataset identifier to a FluidLabelSet.
+   Export the dataset identifier to a FluidLabelSet.
 
 :message merge:
 

--- a/doc/DataSetQuery.rst
+++ b/doc/DataSetQuery.rst
@@ -3,9 +3,7 @@
 :sc-categories: UGens>FluidManipulation
 :sc-related: Classes/FluidDataSet
 :see-also: 
-:description: A selection of columns and a set of conditions that match rows of a FluidDataSet. Use to filter and search in a database of descriptors.
-
-
+:description: A selection of columns and a set of conditions that match rows of a FluidDataSet. Used to filter and search in a database of descriptors.
 
 :message addColumn:
 
@@ -73,7 +71,7 @@
 
    :arg action: Run when done
 
-   Clear the query, remove all columns, filters and limit.
+   Clear the query, remove all columns, filters and limits.
 
 :message transform:
 

--- a/doc/Gain.rst
+++ b/doc/Gain.rst
@@ -1,8 +1,8 @@
-:digest: Real-Time Buffered Gain Changer
+:digest: Realtime Buffered Gain Changer
 :species: transformer
 :sc-categories: UGens>Algebraic, Libraries>FluidDecomposition, UGens>Buffer
 :sc-related: Guides/FluidCorpusManipulation,Classes/UnaryOpFunction
-:description: This class implements a sanity test for the FluCoMa Real-Time Client Wrapper.
+:description: This class implements a sanity test for the FluCoMa Realtime Client Wrapper.
 :see-also: 
 :discussion: 
 :process: The audio rate version of the object.

--- a/doc/Grid.rst
+++ b/doc/Grid.rst
@@ -5,7 +5,7 @@
 :see-also: UMAP, MDS, PCA, DataSet
 :description: Maps a set of 2D points in a :fluid-obj:`DataSet` to a rectangular grid.
 :discussion: 
-   :fluid-obj:`Grid` transforms a two-dimensional dataset into a grid using a variant of the Jonker-Volgenant algorithm (https://www.gwern.net/docs/statistics/decision/1987-jonker.pdf). This can be useful to generate compact grid layouts from the output of dimensionality reduction algorithms such as :fluid-obj:`UMAP`, :fluid-obj:`PCA` or :fluid-obj:`MDS` and for making uniformally distributed spaces out of any two-dimensional dataset.
+   :fluid-obj:`Grid` transforms a two-dimensional dataset into a grid using a variant of the Jonker-Volgenant algorithm (https://www.gwern.net/docs/statistics/decision/1987-jonker.pdf). This can be useful to generate compact grid layouts from the output of dimensionality reduction algorithms such as :fluid-obj:`UMAP`, :fluid-obj:`PCA` or :fluid-obj:`MDS` and for making uniformly distributed spaces out of any two-dimensional dataset.
 
    This approach is similar to projects like CloudToGrid ( https://github.com/kylemcdonald/CloudToGrid/ ), RasterFairy ( https://github.com/Quasimondo/RasterFairy ) or IsoMatch ( https://github.com/ohadf/isomatch ).
 

--- a/doc/HPSS.rst
+++ b/doc/HPSS.rst
@@ -14,7 +14,7 @@
 
    The maskingMode parameter provides different approaches to combining estimates and producing masks. Some settings (especially in modes 1 & 2) will provide better separation but with more artefacts.
    
-   Driedger (2014) suggests that the size of the median filters don't affect the outcome as much as the ``fftSize``. with large FFT sizes, short percussive sounds have less representation, therefore the harmonic component is more strongly represented. The result is that many of the percussive sounds leak into the harmonic component. Small FFT sizes have less resolution in the frequency domain and often lead to a blurring of horizontal structures, therefore harmonic sounds tend to leak into the percussive component. As with all FFT based-processes, finding an FFT size that balances spectral and temporal resolution for a given source sound will benefit the use of this object.
+   Driedger (2014) suggests that the size of the median filters don't affect the outcome as much as the ``fftSize``. With large FFT sizes, short percussive sounds have less representation, therefore the harmonic component is more strongly represented. The result is that many of the percussive sounds leak into the harmonic component. Small FFT sizes have less resolution in the frequency domain and often lead to a blurring of horizontal structures, therefore harmonic sounds tend to leak into the percussive component. As with all FFT based-processes, finding an FFT size that balances spectral and temporal resolution for a given source sound will benefit the use of this object.
 
    For more details visit https://learn.flucoma.org/reference/hpss
    
@@ -50,7 +50,7 @@
          Binary masks provide better separation, but with more artefacts. The harmonic mask is constructed using a binary decision, based on whether a threshold is exceeded for every magnitude in the spectrogram (these are set using ``harmThreshFreq1``, ``harmThreshAmp1``, ``harmThreshFreq2``, ``harmThreshAmp2``, see below). The percussive mask is then formed as the inverse of the harmonic one, meaning that as above, the two components will sum to the original sound.
 
       :2:
-         Soft masks (with a third stream containing a residual component). First, binary masks are made separately for the harmonic and percussive components using different thresholds (set with the respective ``harmThresh-`` and ``percThresh-`` parameters below). Because these masks aren't guaranteed to represent the entire spectrogram, any residual energy is considered as a third output.  The independently created binary masks are converted to soft masks at the end of the process so that everything null sums. 
+         Soft masks (with a third stream containing a residual component). First, binary masks are made separately for the harmonic and percussive components using different thresholds (set with the respective ``harmThresh-`` and ``percThresh-`` parameters below). Because these masks aren't guaranteed to represent the entire spectrogram, any residual energy is considered as a third output.  The independently created binary masks are converted to soft masks at the end of the process so that everything null-sums. 
 
 :control harmThresh:
 

--- a/doc/KMeans.rst
+++ b/doc/KMeans.rst
@@ -9,7 +9,7 @@
 
 :discussion:
 
-   ``KMeans`` facilitates learning of clusters from a :fluid-obj:`DataSet`. This allows you to assign each point in the data a discrete membership to a group or cluster. The algorithm works by paritioning points into discrete clumps that ideally have *equal variance*. See the scitkit-learn reference for a more technical explanation: https://scikit-learn.org/stable/modules/clustering.html#k-means
+   ``KMeans`` facilitates learning of clusters from a :fluid-obj:`DataSet`. This allows you to assign each point in the data a discrete membership to a group or cluster. The algorithm works by partitioning points into discrete clumps that ideally have *equal variance*. See the Scitkit-learn reference for a more technical explanation: https://scikit-learn.org/stable/modules/clustering.html#k-means
 
 :control numClusters:
 

--- a/doc/KNNRegressor.rst
+++ b/doc/KNNRegressor.rst
@@ -18,7 +18,7 @@
 
 :control weight:
 
-   Whether to weight neighbours by distance when producing new point. The default is 1 (true).
+   Whether to weight neighbours by distance when predicting new points. The default is 1 (true).
 
 :message fit:
 

--- a/doc/LabelSet.rst
+++ b/doc/LabelSet.rst
@@ -63,7 +63,7 @@
 
    :arg action: A function to run when the export is done.
 
-   Export to the dataset identifier to a FluidLabelSet.
+   Export the dataset identifier to a FluidLabelSet.
 
 :message write:
 

--- a/doc/Loudness.rst
+++ b/doc/Loudness.rst
@@ -1,4 +1,4 @@
-:digest: A Loudness and True-Peak Descriptor in Real-Time
+:digest: A Loudness and True-Peak Descriptor in Realtime
 :species: descriptor
 :sc-categories: Libraries>FluidDecomposition
 :sc-related: Guides/FluidCorpusManipulation
@@ -7,7 +7,7 @@
 :discussion: 
    Computes the true peak of the signal as well as applying the filters proposed by broadcasting standards to emulate the perception of amplitude.
 
-   The process will return a multichannel control steam with [loudness, truepeak] values, both in dBFS, which will be repeated if no change happens within the algorithm, i.e. when the hopSize is larger than the signal vector size. More information on broadcasting standardisation of loudness measurement is available at the reference page ( https://tech.ebu.ch/docs/tech/tech3341.pdf ) and in more musician-friendly explantions here (http://designingsound.org/2013/02/06/loudness-and-metering-part-1/).
+   The process will return a multichannel control stream with [loudness, truepeak] values, both in dBFS, which will be repeated if no change happens within the algorithm, i.e. when the hopSize is larger than the signal vector size. More information on broadcasting standardisation of loudness measurement is available at the reference page ( https://tech.ebu.ch/docs/tech/tech3341.pdf ) and in more musician-friendly explantions here (http://designingsound.org/2013/02/06/loudness-and-metering-part-1/).
 
 :process: The audio rate in, control rate out version of the object.
 :output: A 2-channel KR signal with the [pitch, confidence] descriptors. The latency is windowSize.

--- a/doc/MDS.rst
+++ b/doc/MDS.rst
@@ -29,7 +29,7 @@
    
    **Symmetric Kullback Leibler Divergence:** Because the first part of this computation uses the logarithm of the values, using the Symmetric Kullback Leibler Divergence only makes sense with non-negative data. https://en.wikipedia.org/wiki/Kullback%E2%80%93Leibler_divergence#Symmetrised_divergence
    
-   .. **Cosine Distance:** Cosine Distance considers each data point a vector in Cartesian space and computes the angle between the two points. It first normalizes these vectors so they both sit on the unit circle and then finds the dot product of the two vectors which returns a calculation of the angle. Therefore this measure does not consider the magnitudes of the vectors when computing distance. https://en.wikipedia.org/wiki/Cosine_similarity (This article describes the cosine _similarity_, as opposed to distance, however since the cosine similarity is always between -1 and 1, the distance is computed as 1 - cosine similarity, which will always range from a minimum distance of 0 to a maximum distance of 2.)
+   .. **Cosine Distance:** Cosine Distance considers each data point a vector in Cartesian space and computes the angle between the two points. It first normalises these vectors so they both sit on the unit circle and then finds the dot product of the two vectors which returns a calculation of the angle. Therefore this measure does not consider the magnitudes of the vectors when computing distance. https://en.wikipedia.org/wiki/Cosine_similarity (This article describes the cosine _similarity_, as opposed to distance, however since the cosine similarity is always between -1 and 1, the distance is computed as 1 - cosine similarity, which will always range from a minimum distance of 0 to a maximum distance of 2.)
 
 :control numDimensions:
 
@@ -57,7 +57,7 @@
       Minkowski Min Distance
 
     :5: 
-      Symmetric Kullback Leibler Divergance
+      Symmetric Kullback Leibler Divergence
 
     .. :6: 
     ..   Cosine Distance

--- a/doc/MFCC.rst
+++ b/doc/MFCC.rst
@@ -1,4 +1,4 @@
-:digest: Mel-Frequency Cepstral Coefficients as Spectral Descriptors in Real-Time
+:digest: Mel-Frequency Cepstral Coefficients as Spectral Descriptors in Realtime
 :species: descriptor
 :sc-categories: Libraries>FluidDecomposition
 :sc-related: Guides/FluidCorpusManipulation
@@ -6,9 +6,9 @@
 :description: A classic timbral audio descriptor, the Mel-Frequency Cepstral Coefficients (MFCCs).
 :discussion: 
 
-   MFCC stands for Mel-Frequency Cepstral Coefficients ("cepstral" is pronounced like "kepstral"). This analysis is often used for timbral description and timbral comparison. It compresses the overall spectrum into a smaller number of coefficients that, when taken together, describe the general contour the spectrum.
+   MFCC stands for Mel-Frequency Cepstral Coefficients ("cepstral" is pronounced like "kepstral"). This analysis is often used for timbral description and timbral comparison. It compresses the overall spectrum into a smaller number of coefficients that, when taken together, describe the general contour of the spectrum.
    
-   The MFCC values are derived by first computing a mel-frequency spectrum, just as in :fluid-obj:`MelBands`. ``numCoeffs`` coefficients are then calculated by using that mel-frequency spectrum as input to the discrete cosine transform. This means that the shape of the mel-frequency spectrum is compared to a number of cosine wave shapes (different cosines shapes created from different frequencies). Each MFCC value (i.e., "coefficient") represents how similar the mel-frequency spectrum is to one of these cosine shapes. 
+   The MFCC values are derived by first computing a mel-frequency spectrum, just as in :fluid-obj:`MelBands`. ``numCoeffs`` coefficients are then calculated by using that mel-frequency spectrum as input to the discrete cosine transform. This means that the shape of the mel-frequency spectrum is compared to a number of cosine wave shapes (different cosine shapes created from different frequencies). Each MFCC value (i.e., "coefficient") represents how similar the mel-frequency spectrum is to one of these cosine shapes. 
    
    Other than the 0th coefficient, MFCCs are unchanged by differences in the overall energy of the spectrum (which relates to how we perceive loudness). This means that timbres with similar spectral contours, but different volumes, will still have similar MFCC values, other than MFCC 0. To remove any indication of loudness but keep the information about timbre, we can ignore MFCC 0 by setting the parameter ``startCoeff`` to 1.
    

--- a/doc/MFCC.rst
+++ b/doc/MFCC.rst
@@ -6,11 +6,11 @@
 :description: A classic timbral audio descriptor, the Mel-Frequency Cepstral Coefficients (MFCCs).
 :discussion: 
 
-   MFCC stands for Mel-Frequency Cepstral Coefficients ("cepstral" is pronounced like "kepstral"). This analysis is often used for timbral description and timbral comparison. It compresses the overall spectrum into a smaller number of coefficients that, when taken together, describe the general contour the the spectrum.
+   MFCC stands for Mel-Frequency Cepstral Coefficients ("cepstral" is pronounced like "kepstral"). This analysis is often used for timbral description and timbral comparison. It compresses the overall spectrum into a smaller number of coefficients that, when taken together, describe the general contour the spectrum.
    
-   The MFCC values are derived by first computing a mel-frequency spectrum, just as in :fluid-obj:`MelBands`. ``numCoeffs`` coefficients are then calculated by using that mel-frequency spectrum as input to the discrete cosine transform. This means that the shape of the mel-frequency spectrum is compared to a number of cosine wave shapes (different cosines shapes created from different different frequencies). Each MFCC value (i.e., "coefficient") represents how similar the mel-frequency spectrum is to one of these cosine shapes. 
+   The MFCC values are derived by first computing a mel-frequency spectrum, just as in :fluid-obj:`MelBands`. ``numCoeffs`` coefficients are then calculated by using that mel-frequency spectrum as input to the discrete cosine transform. This means that the shape of the mel-frequency spectrum is compared to a number of cosine wave shapes (different cosines shapes created from different frequencies). Each MFCC value (i.e., "coefficient") represents how similar the mel-frequency spectrum is to one of these cosine shapes. 
    
-   Other that the 0th coefficient, MFCCs are unchanged by differences in the overall energy of the spectrum (which relates to how we perceive loudness). This means that timbres with similar spectral contours, but different volumes, will still have similar MFCC values, other than MFCC 0. To remove any indication of loudness but keep the information about timbre, we can ignore MFCC 0 by setting the parameter ``startCoeff`` to 1.
+   Other than the 0th coefficient, MFCCs are unchanged by differences in the overall energy of the spectrum (which relates to how we perceive loudness). This means that timbres with similar spectral contours, but different volumes, will still have similar MFCC values, other than MFCC 0. To remove any indication of loudness but keep the information about timbre, we can ignore MFCC 0 by setting the parameter ``startCoeff`` to 1.
    
    .. only_in:: sc
 

--- a/doc/MLPClassifier.rst
+++ b/doc/MLPClassifier.rst
@@ -35,7 +35,7 @@
 
 :control maxIter:
 
-   The number of epochs to train for when ``fit`` is called on the object. An epoch is consists of training on all the data points one time.
+   The number of epochs to train for when ``fit`` is called on the object. An epoch consists of training on all the data points one time.
 
 :control learnRate:
 

--- a/doc/MLPClassifier.rst
+++ b/doc/MLPClassifier.rst
@@ -5,7 +5,7 @@
 :see-also: 
 :description: 
 
-  Perform classification between a :fluid-obj:`DataSet` and a :fluid-obj:`LabelSet` using a Multi-Layer Perception neural network.
+  Perform classification between a :fluid-obj:`DataSet` and a :fluid-obj:`LabelSet` using a Multi-Layer Perceptron neural network.
 
 :discussion:  
 

--- a/doc/MLPRegressor.rst
+++ b/doc/MLPRegressor.rst
@@ -47,7 +47,7 @@
 
 :control maxIter:
 
-   The number of epochs to train for when ``fit`` is called on the object. An epoch is consists of training on all the data points one time.
+   The number of epochs to train for when ``fit`` is called on the object. An epoch consists of training on all the data points one time.
 
 :control learnRate:
 

--- a/doc/MLPRegressor.rst
+++ b/doc/MLPRegressor.rst
@@ -5,7 +5,7 @@
 :see-also: 
 :description: 
 
-  Perform regression between :fluid-obj:`DataSet`\s using a Multi-Layer Perception neural network.
+  Perform regression between :fluid-obj:`DataSet`\s using a Multi-Layer Perceptron neural network.
 
 :discussion:
 

--- a/doc/MelBands.rst
+++ b/doc/MelBands.rst
@@ -6,7 +6,7 @@
 :description: Magnitudes for a number of perceptually-evenly spaced bands.
 :discussion: 
 
-   :fluid-obj:`MelBands` returns a Mel-Frequency Spectrum comprised of the user-defined ``numBands``. The Mel-Frequency Spectrum is a histogram of FFT bins bundled according their relationship to the Mel scale ( https://en.wikipedia.org/wiki/Mel_scale ) which represents frequency space logarithmically, mimicking how humans perceive pitch distance. The name "Mel" derives from the word "melody". The Hz-to-Mel conversion used by :fluid-obj:`MelBands` is ``mel = 1127.01048 * log(hz / 700.0 + 1.0)``. This implementation allows to select the range and number of bands dynamically.
+   :fluid-obj:`MelBands` returns a Mel-Frequency Spectrum comprised of the user-defined ``numBands``. The Mel-Frequency Spectrum is a histogram of FFT bins bundled according their relationship to the Mel scale ( https://en.wikipedia.org/wiki/Mel_scale ) which represents frequency space logarithmically, mimicking how humans perceive pitch distance. The name "Mel" derives from the word "melody". The Hz-to-Mel conversion used by :fluid-obj:`MelBands` is ``mel = 1127.01048 * log(hz / 700.0 + 1.0)``. This implementation allows the selection of the range and number of bands dynamically.
 
    When using a high value for ``numBands``, you may end up with empty channels (filled with zeros) in the MelBands output. This is because there is not enough information in the FFT analysis to properly calculate values for every MelBand. Increasing the ``fftSize`` will ensure you have values for all the MelBands.
    

--- a/doc/NMFFilter.rst
+++ b/doc/NMFFilter.rst
@@ -1,19 +1,19 @@
-:digest: Real-Time Non-Negative Matrix Factorisation with Fixed Bases
+:digest: Realtime Non-Negative Matrix Factorisation with Fixed Bases
 :species: transformer
 :sc-categories: Libraries>FluidDecomposition
 :sc-related: Guides/FluidCorpusManipulation
 :see-also: NMFMatch, BufNMF
 :description: Decomposes and resynthesises a signal against a set of spectral templates
 :discussion: 
-   This uses an slimmed-down version of Nonnegative Matrix Factorisation (NMF, see Lee, Daniel D., and H. Sebastian Seung. 1999. ‘Learning the Parts of Objects by Non-Negative Matrix Factorization’. Nature 401 (6755): 788–91. https://doi.org/10.1038/44565)
+   This uses a slimmed-down version of Nonnegative Matrix Factorisation (NMF, see Lee, Daniel D., and H. Sebastian Seung. 1999. ‘Learning the Parts of Objects by Non-Negative Matrix Factorization’. Nature 401 (6755): 788–91. https://doi.org/10.1038/44565)
 
-   It outputs as a signal the resynthesis of the best factorisation. The spectral templates are presumed to have been produced by the offline NMF process, BufNMF, and must be the correct size with respect to the FFT settings being used (FFT size / 2 + 1 frames long). The components of the decomposition is determined by the number of channels in the supplied buffer of templates, up to a maximum set by the maxComponents parameter.
+   It outputs as a signal the resynthesis of the best factorisation. The spectral templates are presumed to have been produced by the offline NMF process, BufNMF, and must be the correct size with respect to the FFT settings being used (FFT size / 2 + 1 frames long). The components of the decomposition are determined by the number of channels in the supplied buffer of templates, up to a maximum set by the maxComponents parameter.
 
    NMF has been a popular technique in signal processing research for things like source separation and transcription (see e.g. Smaragdis and Brown, Non-Negative Matrix Factorization for Polyphonic Music Transcription.), although its creative potential is so far relatively unexplored. It works iteratively, by trying to find a combination of amplitudes ('activations') that yield the original magnitude spectrogram of the audio input when added together. By and large, there is no unique answer to this question (i.e. there are different ways of accounting for an evolving spectrum in terms of some set of templates and envelopes). In its basic form, NMF is a form of unsupervised learning: it starts with some random data and then converges towards something that minimizes the distance between its generated data and the original:it tends to converge very quickly at first and then level out. Fewer iterations mean less processing, but also less predictable results.
 
    The whole process can be related to a channel vocoder where, instead of fixed bandpass filters, we get more complex filter shapes and the activations correspond to channel envelopes.
 
-:process: The real-time processing method. It takes an audio input, and will yield a audio stream in the form of a multichannel array of size maxComponents . If the bases buffer has fewer than maxComponents channels, the remaining outputs will be zeroed.
+:process: The realtime processing method. It takes an audio input, and will yield an audio stream in the form of a multichannel array of size maxComponents . If the bases buffer has fewer than maxComponents channels, the remaining outputs will be zeroed.
 :output: A multichannel kr output, giving for each basis component the activation amount.
 
 
@@ -35,7 +35,7 @@
 
 :control windowSize:
 
-   The number of samples that are analysed at a time. A lower number yields greater temporal resolution, at the expense of spectral resoultion, and vice-versa.
+   The number of samples that are analysed at a time. A lower number yields greater temporal resolution, at the expense of spectral resolution, and vice-versa.
 
 :control hopSize:
 

--- a/doc/NMFMatch.rst
+++ b/doc/NMFMatch.rst
@@ -1,19 +1,19 @@
-:digest: Real-Time Non-Negative Matrix Factorisation with Fixed Bases
+:digest: Realtime Non-Negative Matrix Factorisation with Fixed Bases
 :species: descriptor
 :sc-categories: Libraries>FluidDecomposition
 :sc-related: Guides/FluidCorpusManipulation
 :see-also: NMFFilter, BufNMF
 :description: Matches an incoming audio signal against a set of spectral templates
 :discussion: 
-   This uses an slimmed-down version of Nonnegative Matrix Factorisation (NMF, Lee, Daniel D., and H. Sebastian Seung. 1999. ‘Learning the Parts of Objects by Non-Negative Matrix Factorization’. Nature 401 (6755): 788–91. https://doi.org/10.1038/44565.)
+   This uses a slimmed-down version of Nonnegative Matrix Factorisation (NMF, Lee, Daniel D., and H. Sebastian Seung. 1999. ‘Learning the Parts of Objects by Non-Negative Matrix Factorization’. Nature 401 (6755): 788–91. https://doi.org/10.1038/44565.)
 
-   It outputs at kr the degree of detected match for each template (the activation amount, in NMF-terms). The spectral templates are presumed to have been produced by the offline NMF process (BufNMF), and must be the correct size with respect to the FFT settings being used (FFT size / 2 + 1 frames long). The components of the decomposition is determined by the number of channels in the supplied buffer of templates, up to a maximum set by the maxComponents parameter.
+   It outputs at kr the degree of detected match for each template (the activation amount, in NMF-terms). The spectral templates are presumed to have been produced by the offline NMF process (BufNMF), and must be the correct size with respect to the FFT settings being used (FFT size / 2 + 1 frames long). The components of the decomposition are determined by the number of channels in the supplied buffer of templates, up to a maximum set by the maxComponents parameter.
 
    NMF has been a popular technique in signal processing research for things like source separation and transcription (see e.g Smaragdis and Brown, Non-Negative Matrix Factorization for Polyphonic Music Transcription.), although its creative potential is so far relatively unexplored. It works iteratively, by trying to find a combination of amplitudes ('activations') that yield the original magnitude spectrogram of the audio input when added together. By and large, there is no unique answer to this question (i.e. there are different ways of accounting for an evolving spectrum in terms of some set of templates and envelopes). In its basic form, NMF is a form of unsupervised learning: it starts with some random data and then converges towards something that minimizes the distance between its generated data and the original:it tends to converge very quickly at first and then level out. Fewer iterations mean less processing, but also less predictable results.
 
    The whole process can be related to a channel vocoder where, instead of fixed bandpass filters, we get more complex filter shapes and the activations correspond to channel envelopes.
 
-:process: The real-time processing method. It takes an audio or control input, and will yield a control stream in the form of a multichannel array of size maxComponents . If the bases buffer has fewer than maxComponents channels, the remaining outputs will be zeroed.
+:process: The realtime processing method. It takes an audio or control input, and will yield a control stream in the form of a multichannel array of size maxComponents . If the bases buffer has fewer than maxComponents channels, the remaining outputs will be zeroed.
 :output: A multichannel kr output, giving for each basis component the activation amount.
 
 
@@ -27,7 +27,7 @@
 
 :control maxComponents:
 
-   The maximum number of elements the NMF algorithm will try to divide the spectrogram of the source in. This dictates the number of output channelsfor the ugen. This cannot be modulated.
+   The maximum number of elements the NMF algorithm will try to divide the spectrogram of the source in. This dictates the number of output channels. This cannot be modulated.
 
 :control iterations:
 
@@ -35,7 +35,7 @@
 
 :control windowSize:
 
-   The number of samples that are analysed at a time. A lower number yields greater temporal resolution, at the expense of spectral resoultion, and vice-versa.
+   The number of samples that are analysed at a time. A lower number yields greater temporal resolution, at the expense of spectral resolution, and vice-versa.
 
 :control hopSize:
 

--- a/doc/NoveltyFeature.rst
+++ b/doc/NoveltyFeature.rst
@@ -35,7 +35,7 @@
 
 :control kernelSize:
 
-   The granularity of the window in which the algorithm looks for change, in samples. A small number will be sensitive to short term changes, and a large number should look for long term changes.
+   The granularity of the window in which the algorithm looks for change in samples. A small number will be sensitive to short term changes, and a large number should look for long term changes.
 
 :control filterSize:
 

--- a/doc/NoveltyFeature.rst
+++ b/doc/NoveltyFeature.rst
@@ -39,7 +39,7 @@
 
 :control filterSize:
 
-   The size of a smoothing filter that is applied on the novelty curve. A larger filter filter size allows for cleaner cuts on very sharp changes.
+   The size of a smoothing filter that is applied on the novelty curve. A larger filter size allows for cleaner cuts on very sharp changes.
 
 :control windowSize:
 

--- a/doc/NoveltySlice.rst
+++ b/doc/NoveltySlice.rst
@@ -1,13 +1,13 @@
-:digest: Real-Time Novelty-Based Slicer
+:digest: Realtime Novelty-Based Slicer
 :species: slicer
 :sc-categories: Libraries>FluidDecomposition
 :sc-related: Guides/FluidCorpusManipulation
 :see-also: BufNoveltySlice, OnsetSlice, AmpSlice, TransientSlice
-:description: A real-time slicer using an algorithm assessing novelty in the signal to estimate the slicing points.
+:description: A realtime slicer using an algorithm assessing novelty in the signal to estimate the slicing points.
 :discussion: 
-   A novelty curve is derived from running a kernel across the diagonal of the similarity matrix, and looking for peak of changes. It implements the algorithm published in 'Automatic Audio Segmentation Using a Measure of Audio Novelty' by J Foote.
+   A novelty curve is derived from running a kernel across the diagonal of the similarity matrix, and looking for peaks of changes. It implements the algorithm published in 'Automatic Audio Segmentation Using a Measure of Audio Novelty' by J Foote.
 
-   The process will return an audio steam with single sample impulses at estimated starting points of the different slices.
+   The process will return an audio stream with single sample impulses at estimated starting points of the different slices.
 
 :output: An audio stream with impulses at detected transients. The latency between the input and the output is hopSize * (((kernelSize+1)/2).asInteger + ((filterSize + 1) / 2).asInteger + 1) samples at maximum.
 
@@ -43,7 +43,7 @@
 
 :control threshold:
 
-   The normalised threshold, between 0 an 1, on the novelty curve to consider it a segmentation point.
+   The normalised threshold, between 0 and 1, on the novelty curve to consider it a segmentation point.
 
 :control filterSize:
 

--- a/doc/NoveltySlice.rst
+++ b/doc/NoveltySlice.rst
@@ -47,7 +47,7 @@
 
 :control filterSize:
 
-   The size of a smoothing filter that is applied on the novelty curve. A larger filter filter size allows for cleaner cuts on very sharp changes.
+   The size of a smoothing filter that is applied on the novelty curve. A larger filter size allows for cleaner cuts on very sharp changes.
 
 :control minSliceLength:
 

--- a/doc/OnsetFeature.rst
+++ b/doc/OnsetFeature.rst
@@ -25,7 +25,7 @@
          **HFC** thresholds on (sum of (squared magnitudes * binNum) / nBins)
 
       :2:
-         **SpectralFlux** thresholds on (diffence in magnitude between consecutive frames, half rectified)
+         **SpectralFlux** thresholds on (difference in magnitude between consecutive frames, half rectified)
 
       :3:
          **MKL** thresholds on (sum of log of magnitude ratio per bin) (or equivalently, sum of difference of the log magnitude per bin) (like Onsets mkl)
@@ -54,7 +54,7 @@
 
 :control frameDelta:
 
-   For certain metrics (HFC, SpectralFlux, MKL, Cosine), the distance does not have to be computed between consecutive frames. By default (0) it is, otherwise this sets the distane between the comparison window in samples.
+   For certain metrics (HFC, SpectralFlux, MKL, Cosine), the distance does not have to be computed between consecutive frames. By default (0) it is, otherwise this sets the distance between the comparison window in samples.
 
 :control windowSize:
 

--- a/doc/OnsetFeature.rst
+++ b/doc/OnsetFeature.rst
@@ -50,7 +50,7 @@
 
 :control filterSize:
 
-   The size of a smoothing filter that is applied on the novelty curve. A larger filter filter size allows for cleaner cuts on very sharp changes.
+   The size of a smoothing filter that is applied on the novelty curve. A larger filter size allows for cleaner cuts on very sharp changes.
 
 :control frameDelta:
 

--- a/doc/OnsetSlice.rst
+++ b/doc/OnsetSlice.rst
@@ -1,4 +1,4 @@
-:digest: Spectral Difference-Based Real-Time Audio Slicer
+:digest: Spectral Difference-Based Realtime Audio Slicer
 :species: slicer
 :sc-categories: Libraries>FluidDecomposition
 :sc-related: Guides/FluidCorpusManipulation
@@ -30,7 +30,7 @@
          **HFC** thresholds on (sum of (squared magnitudes * binNum) / nBins)
 
       :2:
-         **SpectralFlux** thresholds on (diffence in magnitude between consecutive frames, half rectified)
+         **SpectralFlux** thresholds on (difference in magnitude between consecutive frames, half rectified)
 
       :3:
          **MKL** thresholds on (sum of log of magnitude ratio per bin) (or equivalently, sum of difference of the log magnitude per bin) (like Onsets mkl)

--- a/doc/OnsetSlice.rst
+++ b/doc/OnsetSlice.rst
@@ -63,7 +63,7 @@
 
 :control filterSize:
 
-   The size of a smoothing filter that is applied on the novelty curve. A larger filter filter size allows for cleaner cuts on very sharp changes.
+   The size of a smoothing filter that is applied on the novelty curve. A larger filter size allows for cleaner cuts on very sharp changes.
 
 :control frameDelta:
 

--- a/doc/PCA.rst
+++ b/doc/PCA.rst
@@ -64,7 +64,7 @@
 
    :arg action: Run when done
 
-   Given a trained model, transform the data point in ``sourceBuffer`` from the original dimensional space to ``numDimensions`` in PCA-space and write into ``destBuffer``.
+   Given a trained model, transform the data point in ``sourceBuffer`` from the original dimensional space to ``numDimensions`` in PCA-space and write the result into ``destBuffer``.
 
 :message inverseTransformPoint:
 

--- a/doc/Pitch.rst
+++ b/doc/Pitch.rst
@@ -53,7 +53,7 @@
 
 :control unit:
 
-   The unit of the pitch output. The default of 0 indicates to output in Hz. A value of 1 will output MIDI note values.
+   The unit of the pitch output. The default of 0 indicates output in Hz. A value of 1 will output MIDI note values.
 
 :control windowSize:
 

--- a/doc/SKMeans.rst
+++ b/doc/SKMeans.rst
@@ -9,7 +9,7 @@
 
 :discussion:
 
-   :fluid-obj:`SKMeans` is an implementation of KMeans based on cosine distances instead of euclidian ones, measuring the angles between the normalised vectors. 
+   :fluid-obj:`SKMeans` is an implementation of KMeans based on cosine distances instead of euclidean ones, measuring the angles between the normalised vectors. 
    One common application of spherical KMeans is to try and learn features directly from input data (via a :fluid-obj:`DataSet`) without supervision. See this reference for a more technical explanation: https://machinelearningcatalogue.com/algorithm/alg_spherical-k-means.html and https://www-cs.stanford.edu/~acoates/papers/coatesng_nntot2012.pdf for feature extractions.
 
 :control numClusters:
@@ -104,7 +104,7 @@
 
    :arg action: A function to run when complete.
 
-   Overwrites the means (centroids) of each cluster, and declare the object trained.
+   Overwrites the means (centroids) of each cluster, and declares the object trained.
 
 :message clear:
 

--- a/doc/STFTPass.rst
+++ b/doc/STFTPass.rst
@@ -1,9 +1,9 @@
-:digest: Real-Time FFT/IFFT return trip.
+:digest: Realtime FFT/IFFT return trip.
 :species: transformer
 :sc-categories: UGens>Algebraic, Libraries>FluidDecomposition, UGens>Buffer
 :sc-related: Guides/FluidCorpusManipulation,Classes/UnaryOpFunction
 :see-also: 
-:description: This class implements a sanity test for the FluCoMa Real-Time Client FFT/IFFT Wrapper.
+:description: This class implements a sanity test for the FluCoMa Realtime Client FFT/IFFT Wrapper.
 :discussion: 
 :process: The audio rate version of the object.
 :output: Same as input, delayed by the windowSize.

--- a/doc/Sines.rst
+++ b/doc/Sines.rst
@@ -39,7 +39,7 @@
 
 :control minTrackLen:
 
-   The minimum duration, in spectral frames, for a sinusoidal track to be accepted as a partial. It allows to remove bubbly pitchy artefactss, but is more CPU intensive and might reject quick pitch material.
+   The minimum duration, in spectral frames, for a sinusoidal track to be accepted as a partial. It allows to remove bubbly pitchy artefacts, but is more CPU intensive and might reject quick pitch material.
 
 :control trackingMethod:
 

--- a/doc/Sines.rst
+++ b/doc/Sines.rst
@@ -23,7 +23,7 @@
 
 :control bandwidth:
 
-   The number of bins used to resynthesises a peak. It has an effect on CPU cost: the widest is more accurate but more computationally expensive. It is capped at (fftSize / 2) + 1.
+   The number of bins used to resynthesise a peak. It has an effect on CPU cost: the widest is more accurate but more computationally expensive. It is capped at (fftSize / 2) + 1.
 
 :control detectionThreshold:
 

--- a/doc/SpectralShape.rst
+++ b/doc/SpectralShape.rst
@@ -1,4 +1,4 @@
-:digest: Seven Spectral Shape Descriptors in Real-Time
+:digest: Seven Spectral Shape Descriptors in Realtime
 :species: descriptor
 :sc-categories: Libraries>FluidDecomposition
 :sc-related: Guides/FluidCorpusManipulation, Classes/SpecCentroid, Classes/SpecFlatness, Classes/SpecCentroid, Classes/SpecPcile
@@ -12,16 +12,16 @@
      * the spectral centroid (1) in Hertz. This is the point that splits the spectrum in 2 halves of equal energy. It is the weighted average of the magnitude spectrum.
      * the spectral spread (2) in Hertz. This is the standard deviation of the spectrum envelope, or the average of the distance to the centroid.
      * the normalised skewness (3) as ratio. This indicates how tilted is the spectral curve in relation to the middle of the spectral frame, i.e. half of the Nyquist frequency. If it is below the frequency of the magnitude spectrum, it is positive.
-     * the normalised kurtosis (4) as ratio. This indicates how focused is the spectral curve. If it is peaky, it is high.
+     * the normalised kurtosis (4) as ratio. This indicates how focused the spectral curve is. If it is peaky, the value is high.
     
    * the rolloff (5) in Hertz. This indicates the frequency under which 95% of the energy is included.
-   * the flatness (6) in dB. This is the ratio of geometric mean of the magnitude, over the arithmetic mean of the magnitudes. It yields a very approximate measure on how noisy a signal is.
-   * the crest (7) in dB. This is the ratio of the loudest magnitude over the RMS of the whole frame. A high number is an indication of a loud peak poking out from the overal spectral curve.
+   * the flatness (6) in dB. This is the ratio of geometric mean to the magnitude, over the arithmetic mean of the magnitudes. It yields a very approximate measure on how noisy a signal is.
+   * the crest (7) in dB. This is the ratio of the loudest magnitude over the RMS of the whole frame. A high number is an indication of a loud peak poking out from the overall spectral curve.
 
    The drawings in Peeters 2003 ( http://recherche.ircam.fr/anasyn/peeters/ARTICLES/Peeters_2003_cuidadoaudiofeatures.pdf ) are useful, as are the commented examples below. For the mathematically-inclined reader, the tutorials and code offered here  
    ( https://www.audiocontentanalysis.org/ ) are interesting to further the understanding. For examples of the impact of computing the moments in power magnitudes, and/or in exponential frequency scale, please refer to the helpfile.
 
-   The process will return a multichannel control steam with the seven values, which will be repeated if no change happens within the algorithm, i.e. when the hopSize is larger than the signal vector size.
+   The process will return a multichannel control stream with the seven values, which will be repeated if no change happens within the algorithm, i.e. when the hopSize is larger than the signal vector size.
 
 :process: The audio rate in, control rate out version of the object.
 :output: A 7-channel KR signal with the seven spectral shape descriptors. The latency is windowSize.

--- a/doc/SpectralShape.rst
+++ b/doc/SpectralShape.rst
@@ -10,7 +10,7 @@
    * the four first statistical moments (`<https://en.wikipedia.org/wiki/Moment_(mathematics)>`_), more commonly known as:
         
      * the spectral centroid (1) in Hertz. This is the point that splits the spectrum in 2 halves of equal energy. It is the weighted average of the magnitude spectrum.
-     * the spectral spread (2) in Hertz. This is the standard deviation of the spectrum envelop, or the average of the distance to the centroid.
+     * the spectral spread (2) in Hertz. This is the standard deviation of the spectrum envelope, or the average of the distance to the centroid.
      * the normalised skewness (3) as ratio. This indicates how tilted is the spectral curve in relation to the middle of the spectral frame, i.e. half of the Nyquist frequency. If it is below the frequency of the magnitude spectrum, it is positive.
      * the normalised kurtosis (4) as ratio. This indicates how focused is the spectral curve. If it is peaky, it is high.
     

--- a/doc/TransientSlice.rst
+++ b/doc/TransientSlice.rst
@@ -27,7 +27,7 @@
 
 :control blockSize:
 
-  The size of audio chunk (in samples) on which the process is operating. This determines the maximum duration (in samples) of a detected transient, which cannot be more than than half of ``blockSize - order``. High values are more cpu intensive.
+  The size of audio chunk (in samples) on which the process is operating. This determines the maximum duration (in samples) of a detected transient, which cannot be more than half of ``blockSize - order``. High values are more cpu intensive.
 
 :control padSize:
 

--- a/doc/TransientSlice.rst
+++ b/doc/TransientSlice.rst
@@ -1,16 +1,16 @@
-:digest: Transient-Based Real-Time Audio Slicer
+:digest: Transient-Based Realtime Audio Slicer
 :species: slicer
 :sc-categories: Libraries>FluidDecomposition
 :sc-related: Guides/FluidCorpusManipulation
 :see-also: BufTransientSlice, AmpSlice, NoveltySlice, OnsetSlice
-:description: A real-time transient-based slice extractor
+:description: A realtime transient-based slice extractor
 :discussion: 
 
   TransientSlice identifies slice points in a real time signal by implementing a "de-clicking" algorithm based on the assumption that a transient is a sample or series of samples that are anomalous when compared to surrounding samples. It creates a model of the time series of samples, so that when a given sample doesn't fit the model (its "error" or anomalous-ness goes above ``threshFwd``) it is determined to be a transient and a slice point is identified. 
 
   The series of samples determined to be a transient will continue until the error goes below ``threshBack``, indicating that the samples are again more in-line with the model.
 
-  The process will return an audio steam with single sample impulses at estimated starting points of the different slices.
+  The process will return an audio stream with single sample impulses at estimated starting points of the different slices.
 
   The algorithm implemented is from chapter 5 of "Digital Audio Restoration" by Godsill, Simon J., Rayner, Peter J.W. with some bespoke improvements on the detection function tracking.
 
@@ -27,7 +27,7 @@
 
 :control blockSize:
 
-  The size of audio chunk (in samples) on which the process is operating. This determines the maximum duration (in samples) of a detected transient, which cannot be more than half of ``blockSize - order``. High values are more cpu intensive.
+  The size of audio block (in samples) on which the process is operating. This determines the maximum duration (in samples) of a detected transient, which cannot be more than half of ``blockSize - order``. High values are more cpu intensive.
 
 :control padSize:
 
@@ -39,11 +39,11 @@
 
 :control threshFwd:
 
-  The threshold applied to the smoothed forward prediction error for determining an onset. The units are roughly in standard deviations, thus can be considered how "deviant", or anomalous, the signal must be to be detected as a transient. It allows tight start of the identification of the anomaly as it proceeds forward.
+  The threshold applied to the smoothed forward prediction error for determining an onset. The units are roughly in standard deviations, thus can be considered how "deviant", or anomalous, the signal must be to be detected as a transient. It allows tight identification of the start of the anomaly as it proceeds forward.
 
 :control threshBack:
 
-  The threshold applied to the smoothed backward prediction error for determining an offset. The units are roughly in standard deviations, thus can be considered how "deviant", or anomalous, the signal must be to be considered transient. When the smoothed error function goes below ``threshBack`` an offset is identified. As it proceeds backwards in time, it allows tight ending of the identification of the anomaly.
+  The threshold applied to the smoothed backward prediction error for determining an offset. The units are roughly in standard deviations, thus can be considered how "deviant", or anomalous, the signal must be to be considered transient. When the smoothed error function goes below ``threshBack`` an offset is identified. As it proceeds backwards in time, it allows tight identification of the end of the anomaly.
 
 :control windowSize:
 
@@ -51,7 +51,7 @@
 
 :control clumpLength:
 
-  The window size in samples within which anomalous samples will be clumped together to avoid over detecting in time. This is similar to setting a minimum slice length.
+  The window size in samples within which anomalous samples will be clumped together to avoid over-detecting in time. This is similar to setting a minimum slice length.
 
 :control minSliceLength:
 

--- a/doc/Transients.rst
+++ b/doc/Transients.rst
@@ -1,4 +1,4 @@
-:digest: Real-Time Transient Modeller and Extractor
+:digest: Realtime Transient Modeller and Extractor
 :species: transformer
 :sc-categories: Libraries>FluidDecomposition
 :sc-related: Guides/FluidCorpusManipulation
@@ -8,7 +8,7 @@
 
    This implements a "de-clicking" algorithm based on the assumption that a transient is a sample or series of samples that are anomalous when compared to surrounding samples. It creates a model of the time series of samples, so that when a given sample doesn't fit the model (its "error" or anomalous-ness goes above ``threshFwd``) it is determined to be a transient. The series of samples determined to be a transient will continue until the error goes below ``threshBack``, indicating that the samples are again more in-line with the model. 
    
-   The algorithm then estimates what should have happened during the transient period if the signal had followed its non-anomalous path, and resynthesises this estimate to create the residual output. The transient output is ``input signal - residual signal``, such that summed output of the object (``transients + residual``) can still null-sum with the input. 
+   The algorithm then estimates what should have happened during the transient period if the signal had followed its non-anomalous path, and resynthesises this estimate to create the residual output. The transient output is ``input signal - residual signal``, such that the summed output of the object (``transients + residual``) can null-sum with the input. 
 
     The algorithm will take an audio in, and will divide it in two outputs:
     	* the transients, estimated from the signal and extracted from it
@@ -29,7 +29,7 @@
 
 :control blockSize:
 
-   The size of audio chunk (in samples) on which the process is operating. This determines the maximum duration (in samples) of a detected transient, which cannot be more than half of ``blockSize - order``. High values are more cpu intensive.
+   The size of audio block (in samples) on which the process is operating. This determines the maximum duration (in samples) of a detected transient, which cannot be more than half of ``blockSize - order``. High values are more cpu intensive.
 
 :control padSize:
 
@@ -41,11 +41,11 @@
 
 :control threshFwd:
 
-   The threshold applied to the smoothed forward prediction error for determining an onset. The units are roughly in standard deviations, thus can be considered how "deviant", or anomalous, the signal must be to be detected as a transient. It allows tight start of the identification of the anomaly as it proceeds forward.
+   The threshold applied to the smoothed forward prediction error for determining an onset. The units are roughly in standard deviations, thus can be considered how "deviant", or anomalous, the signal must be to be detected as a transient. It allows tight identification of the start of the anomaly as it proceeds forward.
 
 :control threshBack:
 
-   The threshold applied to the smoothed backward prediction error for determining an offset. The units are roughly in standard deviations, thus can be considered how "deviant", or anomalous, the signal must be to be considered transient. When the smoothed error function goes below ``threshBack`` an offset is identified. As it proceeds backwards in time, it allows tight ending of the identification of the anomaly.
+   The threshold applied to the smoothed backward prediction error for determining an offset. The units are roughly in standard deviations, thus can be considered how "deviant", or anomalous, the signal must be to be considered transient. When the smoothed error function goes below ``threshBack`` an offset is identified. As it proceeds backwards in time, it allows tight identification of the end of the anomaly.
 
 :control windowSize:
 
@@ -53,4 +53,4 @@
 
 :control clumpLength:
 
-   The window size in samples within which anomalous samples will be clumped together to avoid over detecting in time. This is like setting a minimum transient length.
+   The window size in samples within which anomalous samples will be clumped together to avoid over-detecting in time. This is like setting a minimum transient length.

--- a/doc/Transients.rst
+++ b/doc/Transients.rst
@@ -29,7 +29,7 @@
 
 :control blockSize:
 
-   The size of audio chunk (in samples) on which the process is operating. This determines the maximum duration (in samples) of a detected transient, which cannot be more than than half of ``blockSize - order``. High values are more cpu intensive.
+   The size of audio chunk (in samples) on which the process is operating. This determines the maximum duration (in samples) of a detected transient, which cannot be more than half of ``blockSize - order``. High values are more cpu intensive.
 
 :control padSize:
 

--- a/doc/UMAP.rst
+++ b/doc/UMAP.rst
@@ -21,7 +21,7 @@
 
 :control numNeighbours:
 
-   The number of neighbours considered by the algorithm to balance local vs global structures to conserve. Low values will prioritise preserving local structure, high values will help preserving the global structure.
+   The number of neighbours considered by the algorithm to balance local vs global structures to conserve. Low values will prioritise preservation of the local structure while high values will prioritise preservation of the global structure.
 
 :control minDist:
 

--- a/example-code/sc/BufAudioTransport.scd
+++ b/example-code/sc/BufAudioTransport.scd
@@ -16,7 +16,7 @@ b.play
 c.play
 d.play
 
-// note that the process is quantized by the spectral bins. For an example of the pros and cons of these settings on this given process, please see the real-time FluidAudioTransport helpfile.
+// note that the process is quantized by the spectral bins. For an example of the pros and cons of these settings on this given process, please see the realtime FluidAudioTransport helpfile.
 
 // more interesting sources: two cardboard bowing gestures
 (

--- a/example-code/sc/BufNMF.scd
+++ b/example-code/sc/BufNMF.scd
@@ -84,7 +84,7 @@ FluidWaveform(featuresBuffer:~bases,bounds:Rect(0,0,1200,300));
 ~resynth.play;
 
 // ======== to further understand NMF's bases and activations, consider one more object: FluidNMFFilter ==========
-// FluidNMFFilter will use the bases (spectral templates) of a FluidBufNMF analysis to filter (i.e., decompose) real-time audio
+// FluidNMFFilter will use the bases (spectral templates) of a FluidBufNMF analysis to filter (i.e., decompose) realtime audio
 
 // for example, if we use the bases from the ~drums analysis above, it will separate the snare from the kick & hi hat like before
 // this time you'll hear one in each stereo channel (again, results may vary)
@@ -97,7 +97,7 @@ FluidWaveform(featuresBuffer:~bases,bounds:Rect(0,0,1200,300));
 }.play;
 )
 
-// if we play a different source through FluidNMFFilter, it will try to decompose that real-time signal according to the bases
+// if we play a different source through FluidNMFFilter, it will try to decompose that realtime signal according to the bases
 // it is given (in our case the bases from the drum loop)
 ~song = Buffer.readChannel(s,FluidFilesPath("Tremblay-BeatRemember.wav"),channels:[0]);
 

--- a/example-code/sc/MFCC.scd
+++ b/example-code/sc/MFCC.scd
@@ -1,7 +1,7 @@
 
 code::
 
-// a window to watch the MFCC analyses in real-time
+// a window to watch the MFCC analyses in realtime
 (
 ~win = Window("MFCCs Monitor",Rect(0,0,800,400)).front;
 ~ms = MultiSliderView(~win,Rect(0,0,~win.bounds.width,~win.bounds.height)).elasticMode_(1).isFilled_(1);
@@ -71,7 +71,7 @@ OSCdef(\mfccs,{
 )
 
 ::
-STRONG::Comparing MFCC Analyses in real-time::
+STRONG::Comparing MFCC Analyses in realtime::
 CODE::
 
 // we'll compare trombone to trombone (but at different playback rates to fake 2 different players

--- a/example-code/sc/MLPClassifier.scd
+++ b/example-code/sc/MLPClassifier.scd
@@ -1,4 +1,4 @@
-strong::Real-Time Tweaking Parameters::
+strong::Realtime Tweaking Parameters::
 code::
 
 s.boot;

--- a/example-code/sc/NMFFilter.scd
+++ b/example-code/sc/NMFFilter.scd
@@ -30,13 +30,13 @@ fork{
 // If the process did not separate out the kick drum, hi hat, and snare drum (in any order) very well, try it again until it does.
 // It will be useful going forward to have bases that pretty well represent these drum instruments.
 
-// FluidNMFFilter will use the bases (spectral templates) of a FluidBufNMF analysis to filter (i.e., decompose) real-time audio
+// FluidNMFFilter will use the bases (spectral templates) of a FluidBufNMF analysis to filter (i.e., decompose) realtime audio
 // First, we'll just send the same drum loop through FluidNMFFilter to hear it in action:
 (
 fork{
 	~n_components.do{
 		arg i;
-		"decomposed part #% filtered in real-time using FluidNMFFilter".format(i+1).postln;
+		"decomposed part #% filtered in realtime using FluidNMFFilter".format(i+1).postln;
 		{
 			var src = PlayBuf.ar(1,~drums,BufRateScale.ir(~drums),doneAction:2);
 			var sig = FluidNMFFilter.ar(src,~bases,~n_components)[i];
@@ -48,7 +48,7 @@ fork{
 )
 
 /* It is seprating the drum instrument components just like it did with FluidBufNMF--the difference here is that it is
-happening in real-time. */
+happening in realtime. */
 
 // This means one could different FX to each instrument:
 
@@ -69,7 +69,7 @@ happening in real-time. */
 )
 
 /* This also means that one could send a live input audio signal through FluidNMFFilter and get these
-drum instruments similarly decomposed into separate audio streams in *real-time*. */
+drum instruments similarly decomposed into separate audio streams in *realtime*. */
 
 /* To test an idea like this, we could train it on just the first few seconds of this drum loop (like a training set when using
 a neural network) and then see how it peforms on audio it hasn't seen before: the rest of the drum loop (similar to using
@@ -92,7 +92,7 @@ FluidBufNMF.processBlocking(s,~drums_training,bases:~bases_from_training,compone
 fork{
 	3.do{
 		arg i;
-		"decomposed part #% filtered in real-time using FluidNMFFilter\n\tIt has never heard this part of the drum loop!\n".format(i+1).postln;
+		"decomposed part #% filtered in realtime using FluidNMFFilter\n\tIt has never heard this part of the drum loop!\n".format(i+1).postln;
 		{
 			var src = PlayBuf.ar(1,~drums_testing,BufRateScale.ir(~drums_testing),doneAction:2);
 			var sig = FluidNMFFilter.ar(src,~bases_from_training,3)[i];
@@ -103,7 +103,7 @@ fork{
 };
 )
 
-// If we play a different source through FluidNMFFilter, it will try to decompose that real-time signal according to the bases
+// If we play a different source through FluidNMFFilter, it will try to decompose that realtime signal according to the bases
 // it is given (in our case the bases from the drum loop)
 
 ~song = Buffer.readChannel(s,FluidFilesPath("Tremblay-BeatRemember.wav"),channels:[0]);
@@ -112,7 +112,7 @@ fork{
 fork{
 	~n_components.do{
 		arg i;
-		"decomposed part #% filtered in real-time using FluidNMFFilter".format(i+1).postln;
+		"decomposed part #% filtered in realtime using FluidNMFFilter".format(i+1).postln;
 		{
 			var src = PlayBuf.ar(1,~song,BufRateScale.ir(~song),doneAction:2);
 			var sig = FluidNMFFilter.ar(src,~bases,~n_components)[i];


### PR DESCRIPTION
Fixes typos and other errors strewn throughout.

- various typos
- remove hyphen
- more typos
- various typos/non-grammatical errors
- typos in example code
