### PR TITLE
[docs] Update see-also content

### DIFF
--- a/doc/AmpFeature.rst
+++ b/doc/AmpFeature.rst
@@ -3,6 +3,7 @@
 :sc-categories: Libraries>FluidDecomposition
 :sc-related: Guides/FluidCorpusManipulation
 :see-also: AmpGate, AmpSlice, OnsetFeature, NoveltyFeature
+:max-seealso: peakamp~, meter~, snapshot~, slide~
 :description: Calculate the amplitude differential feature in realtime.
 :discussion: 
     :fluid-obj:`AmpSlice` uses the differential between a fast and a slow envelope follower to determine changes in amplitude. This object calculates the amplitude differential and copies it to an output buffer.

--- a/doc/AmpGate.rst
+++ b/doc/AmpGate.rst
@@ -3,6 +3,7 @@
 :sc-categories: Libraries>FluidDecomposition
 :sc-related: Guides/FluidCorpusManipulation
 :see-also: BufAmpGate, AmpSlice, OnsetSlice, NoveltySlice, TransientSlice
+:max-seealso: peakamp~, meter~, snapshot~, slide~
 :description: Absolute amplitude threshold gate detector on a realtime signal
 
 :discussion: 

--- a/doc/AmpSlice.rst
+++ b/doc/AmpSlice.rst
@@ -3,6 +3,7 @@
 :sc-categories: Libraries>FluidDecomposition
 :sc-related: Guides/FluidCorpusManipulation
 :see-also: BufAmpSlice, AmpGate, OnsetSlice, NoveltySlice, TransientSlice
+:max-seealso: peakamp~, meter~, snapshot~, slide~
 :description: Implements an amplitude-based slicer, with various customisable options and conditions to detect relative amplitude changes as onsets.
 :discussion: 
    FluidAmpSlice is based on two envelope followers on a high-passed version of the signal: one slow that gives the trend, and one fast. Each has features that will interact. The example code below is unfolding the various possibilities in order of complexity.

--- a/doc/BufAmpFeature.rst
+++ b/doc/BufAmpFeature.rst
@@ -3,6 +3,7 @@
 :sc-categories: Libraries>FluidDecomposition
 :sc-related: Guides/FluidCorpusManipulation
 :see-also: BufAmpSlice, BufNoveltyFeature, BufAmpFeature, BufOnsetFeature
+:max-seealso: peakamp~, meter~, snapshot~, slide~
 :description: Calculate the amplitude differential feature used by :fluid-obj:`BufAmpSlice`.
 :discussion: 
     :fluid-obj:`BufAmpSlice` uses the differential between a fast and a slow envelope follower to determine changes in amplitude. This object calculates the amplitude differential and copies it to an output buffer.

--- a/doc/BufAmpGate.rst
+++ b/doc/BufAmpGate.rst
@@ -3,6 +3,7 @@
 :sc-categories: Libraries>FluidDecomposition
 :sc-related: Guides/FluidCorpusManipulation
 :see-also: AmpGate, BufAmpSlice, BufOnsetSlice, BufNoveltySlice, BufTransientSlice
+:max-seealso: peakamp~, meter~, snapshot~, slide~
 :description: Absolute amplitude threshold gate detector on audio in a buffer
 
 :discussion: 

--- a/doc/BufAmpSlice.rst
+++ b/doc/BufAmpSlice.rst
@@ -3,6 +3,7 @@
 :sc-categories: Libraries>FluidDecomposition
 :sc-related: Guides/FluidCorpusManipulation
 :see-also: AmpSlice, BufAmpGate, BufOnsetSlice, BufNoveltySlice, BufTransientSlice
+:max-seealso: peakamp~, meter~, snapshot~, slide~
 :description: Implements an amplitude-based slicer, with various customisable options and conditions to detect relative amplitude changes as onsets.
 :discussion: 
    FluidBufAmpSlice is based on two envelope followers on a high-passed version of the signal: one slow that gives the trend, and one fast. Each has features that will interact. The example code below is unfolding the various possibilities in order of complexity.

--- a/doc/BufCompose.rst
+++ b/doc/BufCompose.rst
@@ -3,6 +3,7 @@
 :sc-categories: Libraries>FluidDecomposition, UGens>Buffer
 :sc-related: Guides/FluidCorpusManipulation, Classes/Buffer
 :see-also: BufSelect, BufSelectEvery
+:max-seealso: poke~, peek~, index~, buffer~
 :description: 
    A utility for manipulating the contents of buffers.
 

--- a/doc/BufFlatten.rst
+++ b/doc/BufFlatten.rst
@@ -3,6 +3,7 @@
 :sc-categories: FluidCorpusManipulation
 :sc-related: Classes/Buffer
 :see-also: BufCompose, BufStats
+:max-seealso: poke~, peek~, index~, buffer~
 :description: 
    Flatten a multichannel |buffer| to a single channel. This can be useful to structure a buffer such that it can be added to a :fluid-obj:`DataSet`
 :discussion:

--- a/doc/BufLoudness.rst
+++ b/doc/BufLoudness.rst
@@ -3,6 +3,7 @@
 :sc-categories: Libraries>FluidDecomposition
 :sc-related: Guides/FluidCorpusManipulation
 :see-also: Loudness, BufPitch, BufMelBands, BufMFCC, BufSpectralShape, BufStats
+:max-seealso: peakamp~, meter~
 :description: Two loudness descriptors, computing the true peak of the signal as well as applying the filters proposed by broadcasting standards to emulate the perception of amplitude.
 :discussion: 
    The process will return a multichannel buffer with two channels per input channel, one for loudness and one for the true peak value of the frame, both in dBfs.

--- a/doc/BufPitch.rst
+++ b/doc/BufPitch.rst
@@ -3,6 +3,7 @@
 :sc-categories: Libraries>FluidDecomposition
 :sc-related: Guides/FluidCorpusManipulation, Classes/SpecCentroid, Classes/SpecFlatness, Classes/SpecCentroid, Classes/SpecPcile
 :see-also: Pitch, BufLoudness, BufMelBands, BufMFCC, BufSpectralShape, BufStats
+:max-seealso: fzero~, retune~
 :description: Three popular pitch descriptors, all of which compute frequency and the confidence that a pitch is present.
 :discussion: 
 

--- a/doc/BufSTFT.rst
+++ b/doc/BufSTFT.rst
@@ -2,7 +2,8 @@
 :species: buffer-proc
 :sc-categories: FluidCorpusManipulation
 :sc-related: Classes/Buffer
-:see-also: 
+:see-also:
+:max-seealso: pfft~
 :description: 
 
    Performs either a forward or inverse Short-Time Fourier Transform (STFT) on a single channel ``source`` |buffer|. 

--- a/doc/BufScale.rst
+++ b/doc/BufScale.rst
@@ -3,6 +3,7 @@
 :sc-categories: Libraries>FluidDecomposition
 :sc-related: Guides/FluidCorpusManipulation, Guides/FluidBufMultiThreading
 :see-also: BufThresh, BufCompose, BufFlatten
+:max-seealso: poke~, peek~, index~, buffer~
 :description: Scale |buffer| values from an input range to an output range.
 :discussion: This object is for scaling |buffer| values. It copies data from a source |buffer| to a destination |buffer|, scaling the source from an input range to an output range.
 

--- a/doc/BufSelect.rst
+++ b/doc/BufSelect.rst
@@ -3,6 +3,7 @@
 :sc-categories: FluidCorpusManipulation
 :sc-related: Classes/Buffer
 :see-also: BufSelectEvery
+:max-seealso: poke~, peek~, index~, buffer~
 :description: Copies sets of values from a buffer, described in terms of a list of frame indices and channel numbers.
 
 

--- a/doc/BufSelectEvery.rst
+++ b/doc/BufSelectEvery.rst
@@ -3,6 +3,7 @@
 :sc-categories: FluidCorpusManipulation
 :sc-related: Classes/Buffer
 :see-also: BufSelect
+:max-seealso: poke~, peek~, index~, buffer~
 :description: Pick every N frames and / or channels from a buffer, described in terms of independent hop sizes for frames and channels
 
 

--- a/doc/BufStats.rst
+++ b/doc/BufStats.rst
@@ -14,11 +14,11 @@
   
   For example if the input to :fluid-obj:`BufStats` is a three-channel buffer and ``numDerivs`` = 1 the output ``stats`` buffer would contain:
    
-   ========= ============ ============= ============= ======== =========== ======== ================= ==================== ===================== ===================== ================ =================== ================
+   ========= ============ ============= ============= ======== =========== ========= ================= ==================== ===================== ===================== ================ =================== =================
    ch 0 mean ch 0 std dev ch 0 skewness ch 0 kurtosis ch 0 low ch 0 middle ch 0 high ch 0 deriv 1 mean ch 0 deriv 1 std dev ch 0 deriv 1 skewness ch 0 deriv 1 kurtosis ch 0 deriv 1 low ch 0 deriv 1 middle ch 0 deriv 1 high
    ch 1 mean ch 1 std dev ch 1 skewness ch 1 kurtosis ch 1 low ch 1 middle ch 1 high ch 1 deriv 1 mean ch 1 deriv 1 std dev ch 1 deriv 1 skewness ch 1 deriv 1 kurtosis ch 1 deriv 1 low ch 1 deriv 1 middle ch 1 deriv 1 high
    ch 2 mean ch 2 std dev ch 2 skewness ch 2 kurtosis ch 2 low ch 2 middle ch 2 high ch 2 deriv 1 mean ch 2 deriv 1 std dev ch 2 deriv 1 skewness ch 2 deriv 1 kurtosis ch 2 deriv 1 low ch 2 deriv 1 middle ch 2 deriv 1 high
-   ========= ============ ============= ============= ======== =========== ======== ================= ==================== ===================== ===================== ================ =================== ================    
+   ========= ============ ============= ============= ======== =========== ========= ================= ==================== ===================== ===================== ================ =================== =================   
 
 :process: This is the method that calls for the statistical analysis to be calculated on ``source``.
 

--- a/doc/DataSet.rst
+++ b/doc/DataSet.rst
@@ -2,7 +2,8 @@
 :species: data
 :sc-categories: UGens>FluidManipulation
 :sc-related: Classes/FluidLabelSet, Classes/FluidKDTree, Classes/FluidKNNClassifier, Classes/FluidKNNRegressor, Classes/FluidKMeans
-:see-also: 
+:see-also: LabelSet, DataSetQuery
+:max-seealso: coll, dict
 :description: FluidDataSet is a container associating data points with identifiers.
 
 

--- a/doc/DataSetQuery.rst
+++ b/doc/DataSetQuery.rst
@@ -2,7 +2,8 @@
 :species: data
 :sc-categories: UGens>FluidManipulation
 :sc-related: Classes/FluidDataSet
-:see-also: 
+:see-also: DataSet, LabelSet
+:max-seealso: coll, dict
 :description: A selection of columns and a set of conditions that match rows of a FluidDataSet. Used to filter and search in a database of descriptors.
 
 :message addColumn:

--- a/doc/KMeans.rst
+++ b/doc/KMeans.rst
@@ -2,7 +2,7 @@
 :species: data
 :sc-categories: FluidManipulation
 :sc-related: Classes/FluidDataSet, Classes/FluidLabelSet, Classes/FluidKNNClassifier, Classes/FluidKNNRegressor, Classes/FluidSKMeans
-:see-also: SKMeans, KNNClassifier, MLPClassifier, DataSet
+:see-also: SKMeans, KNNClassifier, MLPClassifier, DataSet, LabelSet
 :description: 
 
    Uses the K-means algorithm to learn clusters from a :fluid-obj:`DataSet`.

--- a/doc/KNNClassifier.rst
+++ b/doc/KNNClassifier.rst
@@ -2,7 +2,7 @@
 :species: data
 :sc-categories: Classification, KNN
 :sc-related: Classes/FluidKNNRegressor, Classes/FluidDataSet, Classes/FluidLabelSet, Classes/FluidMLPClassifier
-:see-also: 
+:see-also: KNNRegressor, DataSet, MLPClassifier
 :description: A nearest neighbour classifier using a :fluid-obj:`KDTree` .
 
 :discussion:

--- a/doc/KNNRegressor.rst
+++ b/doc/KNNRegressor.rst
@@ -2,7 +2,7 @@
 :species: data
 :sc-categories: Regression
 :sc-related: Classes/FluidKNNClassifier, Classes/FluidDataSet
-:see-also: 
+:see-also: KNNClassifier, DataSet, MLPRegressor
 :description: Regression between DataSets using weighted average of neighbours
 :discussion:
    

--- a/doc/Loudness.rst
+++ b/doc/Loudness.rst
@@ -3,6 +3,7 @@
 :sc-categories: Libraries>FluidDecomposition
 :sc-related: Guides/FluidCorpusManipulation
 :see-also: BufLoudness, Pitch, MelBands, MFCC, SpectralShape
+:max-seealso: peakamp~, meter~
 :description: Two loudness descriptors, with a ITU BS 1770 mode
 :discussion: 
    Computes the true peak of the signal as well as applying the filters proposed by broadcasting standards to emulate the perception of amplitude.

--- a/doc/MDS.rst
+++ b/doc/MDS.rst
@@ -2,7 +2,7 @@
 :species: data
 :sc-categories: Dimensionality Reduction, Data Processing
 :sc-related: Classes/FluidMDS, Classes/FluidDataSet
-:see-also: 
+:see-also: UMAP, PCA, DataSet
 :description: 
 
    Dimensionality Reduction of a :fluid-obj:`DataSet` Using Multidimensional Scaling

--- a/doc/MLPClassifier.rst
+++ b/doc/MLPClassifier.rst
@@ -2,7 +2,7 @@
 :species: data
 :sc-categories: Machine learning
 :sc-related: Classes/FluidMLPRegressor, Classes/FluidDataSet, Classes/FluidLabelSet
-:see-also: 
+:see-also: MLPRegressor, KNNClassifier, DataSet, LabelSet
 :description: 
 
   Perform classification between a :fluid-obj:`DataSet` and a :fluid-obj:`LabelSet` using a Multi-Layer Perceptron neural network.

--- a/doc/MLPRegressor.rst
+++ b/doc/MLPRegressor.rst
@@ -2,7 +2,7 @@
 :species: data
 :sc-categories: Machine learning
 :sc-related: Classes/FluidMLPClassifier, Classes/FluidDataSet
-:see-also: 
+:see-also: KNNRegressor, DataSet, MLPClassifier
 :description: 
 
   Perform regression between :fluid-obj:`DataSet`\s using a Multi-Layer Perceptron neural network.

--- a/doc/PCA.rst
+++ b/doc/PCA.rst
@@ -2,7 +2,7 @@
 :species: data
 :sc-categories: Dimensionality Reduction, Data Processing
 :sc-related: Classes/FluidMDS, Classes/FluidDataSet
-:see-also: 
+:see-also: UMAP, MDS, DataSet
 :description: 
    Principal Components Analysis (PCA) of a :fluid-obj:`DataSet`. 
   

--- a/doc/Pitch.rst
+++ b/doc/Pitch.rst
@@ -3,6 +3,7 @@
 :sc-categories: Libraries>FluidDecomposition
 :sc-related: Guides/FluidCorpusManipulation, Classes/Pitch
 :see-also: BufPitch, MFCC, MelBands, Loudness, SpectralShape
+:max-seealso: fzero~, retune~
 :description: Three popular monophonic pitch descriptors, all of which compute frequency and confidence.
 :discussion: 
 

--- a/doc/RobustScale.rst
+++ b/doc/RobustScale.rst
@@ -2,7 +2,7 @@
 :species: data
 :sc-categories: FluidManipulation
 :sc-related: Classes/FluidStandardize, Classes/FluidNormalize, Classes/FluidDataSet
-:see-also: 
+:see-also: Normalize, Standardize 
 :description: 
 
    Apply Robust Scaling to a :fluid-obj:`DataSet` based on statistics of the data such that each dimension has a median centred on 0 and a range of 1 from the ``low`` percentile to the ``high`` percentile.

--- a/doc/Standardize.rst
+++ b/doc/Standardize.rst
@@ -2,7 +2,7 @@
 :species: data
 :sc-categories: FluidManipulation
 :sc-related: Classes/FluidDataSet, Classes/FluidStandardize
-:see-also: 
+:see-also: Normalize, RobustScale
 :description: 
    Standardize a :fluid-obj:`DataSet`. Rescale using its mean(s) and standard deviation(s) in each dimension, such that each dimension has a mean of 0 and a standard deviation of 1.
    

--- a/doc/Stats.rst
+++ b/doc/Stats.rst
@@ -2,7 +2,7 @@
 :species: descriptor
 :sc-categories: Libraries>FluidDecomposition
 :sc-related: Guides/FluidCorpusManipulation
-:see-also: BufStats, Standardize
+:see-also: BufStats, Standardize, Normalize, RobustScale
 :description: Computes the rolling mean and sample standard deviation over a given window for multichannel control inputs.
 :discussion: 
 

--- a/doc/Transients.rst
+++ b/doc/Transients.rst
@@ -2,7 +2,7 @@
 :species: transformer
 :sc-categories: Libraries>FluidDecomposition
 :sc-related: Guides/FluidCorpusManipulation
-:see-also: BufTransients,Sines,HPSS
+:see-also: BufTransients, Sines, HPSS
 :description: Separate transients from a signal.
 :discussion: 
 

--- a/doc/UMAP.rst
+++ b/doc/UMAP.rst
@@ -2,7 +2,7 @@
 :species: data
 :sc-categories: Dimensionality Reduction, Data Processing
 :sc-related: Classes/FluidMDS, Classes/FluidDataSet
-:see-also: 
+:see-also: MDS, PCA, DataSet 
 :description: Reduce the dimensions of a :fluid-obj:`DataSet` using the Uniform Manifold Approximation and Projection (UMAP) algorithm.
 :discussion: 
    Performs dimensionality reduction of a :fluid-obj:`DataSet` using Uniform Manifold Approximation and Projection (UMAP)


### PR DESCRIPTION
Updates much of the see-also key in the RST which was largely empty for many objects.

Also fills in relevant :max-seealso: information where appropriate, for example, bufpitch~ and fzero~.
