### PR TITLE
[docs] Buffer clients link to buffer management tutorial

### DIFF
--- a/flucoma/doc/templates/maxref.xml
+++ b/flucoma/doc/templates/maxref.xml
@@ -168,7 +168,7 @@ under the European Union’s Horizon 2020 research and innovation programme
     <seealso name='{{ s }}' /> 
     {% endfor %}
     {%- if client_name.startswith('Buf')  -%}
-    <seealso module='flucoma' type='vignette' name="" />
+    <seealso module='flucoma' type='vignette' name="Automatic buffer~ and fluid.dataset~ management" />
     {%- endif -%}
 	</seealsolist>
 </c74object>

--- a/flucoma/doc/templates/maxref.xml
+++ b/flucoma/doc/templates/maxref.xml
@@ -168,7 +168,7 @@ under the European Union’s Horizon 2020 research and innovation programme
     <seealso name='{{ s }}' /> 
     {% endfor %}
     {%- if client_name.startswith('Buf')  -%}
-    <seealso module='flucoma' type='vignette' name="Automatic buffer~ and fluid.dataset~ management" />
+    <seealso module='flucoma' type='vignette' name="buffermanagement" />
     {%- endif -%}
 	</seealsolist>
 </c74object>

--- a/flucoma/doc/templates/maxref.xml
+++ b/flucoma/doc/templates/maxref.xml
@@ -167,8 +167,8 @@ under the European Union’s Horizon 2020 research and innovation programme
     {% for s in max_seealso %}
     <seealso name='{{ s }}' /> 
     {% endfor %}
-    {%- if client_name.startswith('Buf')  -%}
-    <seealso module='flucoma' type='vignette' name="buffermanagement" />
+    {%- if client_name.startswith('Buf') or species == 'data' -%}
+    <seealso module='flucoma' type='vignette' name="automatic_buffer_and_dataset_management" />
     {%- endif -%}
 	</seealsolist>
 </c74object>

--- a/flucoma/doc/templates/maxref.xml
+++ b/flucoma/doc/templates/maxref.xml
@@ -167,5 +167,8 @@ under the European Union’s Horizon 2020 research and innovation programme
     {% for s in max_seealso %}
     <seealso name='{{ s }}' /> 
     {% endfor %}
+    {%- if client_name.startswith('Buf')  -%}
+    <seealso module='flucoma' type='vignette' name="" />
+    {%- endif -%}
 	</seealsolist>
 </c74object>


### PR DESCRIPTION
Adds some additional templating to the maxref template in order to link to the buffer management tutorial if the client is a buffer one.

Is contingent on:

https://github.com/flucoma/flucoma-max/pull/300
