### PR TITLE
bufampfeature + bufnoveltyfeature + bufonsetfeature: fix the doc

### DIFF
--- a/doc/BufAmpFeature.rst
+++ b/doc/BufAmpFeature.rst
@@ -13,11 +13,11 @@
 
 :control source:
 
-   The buffer to use as the source material to be sliced through novelty identification. The different channels of multichannel buffers will be summed.
+   The |buffer| to use as the source material for the amplitude differential curve to be computed. Contrary to |BufAmpSlice| the different channels of multichannel buffers will not be summed but will be processed sequentially.
 
 :control startFrame:
 
-   Where in the srcBuf should the slicing process start, in samples.
+  The starting point for analysis in the source (in frames).
 
 :control numFrames:
 
@@ -25,7 +25,11 @@
 
 :control startChan:
 
-   For multichannel sources, which channel should be processed.
+   For multichannel srcBuf, the starting channel to analyse.
+
+:control numChans:
+
+   For multichannel srcBuf, the number of channels to analyse.
 
 :control numChans:
 

--- a/doc/BufNoveltyFeature.rst
+++ b/doc/BufNoveltyFeature.rst
@@ -20,11 +20,11 @@
 
 :control source:
 
-   The buffer to use as the source material to be sliced through novelty identification. The different channels of multichannel buffers will be summed.
+   The |buffer| to use as the source material for the novelty curve to be computed. Contrary to |BufNoveltySlice| the different channels of multichannel buffers will not be summed but will be processed sequentially.
 
 :control startFrame:
 
-   Where in the srcBuf should the slicing process start, in samples.
+  The starting point for analysis in the source (in frames).
 
 :control numFrames:
 
@@ -32,11 +32,11 @@
 
 :control startChan:
 
-   For multichannel srcBuf, which channel should be processed.
+   For multichannel srcBuf, the starting channel to analyse.
 
 :control numChans:
 
-   For multichannel srcBuf, how many channels should be summed.
+   For multichannel srcBuf, the number of channels to analyse.
 
 :control features:
 

--- a/doc/BufOnsetFeature.rst
+++ b/doc/BufOnsetFeature.rst
@@ -18,11 +18,11 @@
 
 :control source:
 
-   The buffer to use as the source material to be sliced through novelty identification. The different channels of multichannel buffers will be summed.
+   The |buffer| to use as the source material for the onset detection curve to be computed. Contrary to |BufOnsetSlice| the different channels of multichannel buffers will not be summed but will be processed sequentially.
 
 :control startFrame:
 
-   Where in the srcBuf should the slicing process start, in samples.
+  The starting point for analysis in the source (in frames).
 
 :control numFrames:
 
@@ -30,11 +30,11 @@
 
 :control startChan:
 
-   For multichannel sources, which channel should be processed.
+   For multichannel srcBuf, the starting channel to analyse.
 
 :control numChans:
 
-   For multichannel sources, how many channels should be summed.
+   For multichannel srcBuf, the number of channels to analyse.
 
 :control features:
 


### PR DESCRIPTION
it seems we were copy-paste trigger happy - so fixed now each curve name :) and also the fact that multichannel input buf is treated like any other descriptor (with a note on the difference with their buf*slice counterpart)

@jamesb93 just a quick check that my english is not offensively bad? merge away if you're happy